### PR TITLE
docs(code-of-conduct): revise domain following updated documentation standards

### DIFF
--- a/documents/.github/instructions/documentation-style-link.instructions.md
+++ b/documents/.github/instructions/documentation-style-link.instructions.md
@@ -1,0 +1,189 @@
+# Documentation, Style & Link Management Lessons
+
+tag: documentation, writing, style, formatting, markdown, links
+
+## Purpose
+This document provides clear, concise, and complete instructions for writing, formatting, and linking documentation. It is designed for both human and AI authors to ensure consistency and quality across all project documentation.
+
+## Scope
+Comprehensive guidelines for writing clear, professional, consistently formatted, and well-linked documentation for the project.
+
+## MANDATORY: Titles and Tags
+
+- Visible H1 titles: Every Markdown page MUST begin its content with a visible H1 heading (first body line after front matter): `# Page Title`.
+  - Do NOT use `title:` in front matter. If present, remove it to avoid duplicate titles.
+  - Only one H1 per page (MD025). Subsequent sections start at H2 (`##`).
+- Required tags: Every page MUST include a `tags:` list in YAML front matter with relevant, specific tags (2–6 recommended).
+  - Prefer domain- and concept-specific tags (e.g., `team`, `roster`, `tournament`, `ranking`, `finance`, `payment`, `identity`, `profile`, `venue`, `schedule`).
+  - Use lowercase, hyphenated tokens when multi-word (e.g., `first-aid`, `match-system`).
+
+Template (copy/paste):
+
+---
+tags:
+  - domain
+  - subdomain
+  - concept
+---
+
+# Page Title
+
+Intro paragraph…
+
+Notes
+- The Tags plugin is enabled; tags power search and taxonomy pages.
+- Lint rules enforce a single H1 (MD025) and first-line H1 (MD041) when configured for visible titles.
+- When converting existing pages: remove `title:` from front matter, add `# Page Title` as the first body line, keep/curate `tags:`.
+
+## Key Lessons
+
+### Writing & Structure
+- For all template entities, always reference standard attributes from the Base Entity (e.g., "This template entity includes standard attributes from the [Base Entity](../foundation/base_entity.md)") instead of listing them explicitly. This ensures documentation remains maintainable and up to date if the Base Entity changes.
+- Use direct, active voice and concise sentences.
+- Organize content with clear headings, lists, and sections.
+- Adapt writing for the intended audience:
+  - For technical readers, use precise terminology and provide detailed explanations (without code blocks).
+  - For non-technical readers, avoid jargon, explain concepts simply, and use analogies or visuals where helpful.
+- Begin each domain file with a brief summary or introduction.
+- Use the following section order in domain files: Overview, Purpose, Structure, Example, See Also.
+- In the Structure section, always reference the Base Entity for standard attributes (do not list them explicitly). This ensures maintainability if the Base Entity changes. Always include an attributes table for template entities to provide clarity and quick reference for users.
+- Remove sections for Relationships, Key Concepts, and References unless absolutely necessary. Prioritize clarity and relevance. Ensure documentation supports both human and automated validation, emphasizing transparency, consistency, and adaptability for future use cases.
+Add an Example section after Structure to illustrate domain concepts with real-world scenarios or visuals (e.g., mermaid diagrams). Follow these best practices:
+  - Always provide contextual explanations for each example, immediately following the example.
+  - MANDATORY: Ensure every example represents ALL attributes from the Structure section, both visually (in the diagram) and explicitly in the explanatory paragraph.
+  - If a single diagram would become unreadable, use two small diagrams (Example A/B) to cover all attributes.
+  - Do not add “Also shows” bullet lists. Prefer additional small diagrams or a second example to cover remaining attributes.
+  - Use descriptive, domain-relevant values in examples (avoid technical identifiers or placeholders).
+  - Provide multiple examples for different use cases or variations when possible.
+  - Use readable diagram formats (e.g., `A --> B[Attribute: Value]`) for mermaid diagrams to improve comprehension.
+  - Avoid repetitive or superficial explanations; provide expert-level context that clarifies the purpose, logic, and practical application of each template entity.
+  - Avoid confusing or overly abstract examples unless specifically required for the domain.
+  - Prefer Mermaid flowcharts using `graph TD` for clarity and left-to-right/top-down readability.
+  - Immediately follow each diagram with a concise paragraph that explains the structure and its practical impact (why it matters for organizers, navigation, eligibility, reporting, etc.).
+
+  ### Modeling Rules (Data, Embedding, Terminology)
+  - Embedding within the same domain (document database model):
+    - When one model references another model in the SAME domain (e.g., `discipline/*` → `discipline/stage/*`), embed the referenced model instead of using a UUID. Reflect this in docs:
+      - Use types like `Stage Format`, `Match System`, `List[Stage Phase]`, `List[Stage Tiebreaker]`, `List[Match Unit]`, etc., not `UUID`/`List[UUID]`.
+      - Examples must illustrate embedded/nested data, not identifiers.
+    - If the referenced model is in a DIFFERENT domain (e.g., `discipline/*` → `ranking/*` or `classification/measurement/*`), keep it as a reference by UUID.
+  - Terminology: Teams vs. Participants
+    - Use "team"/"teams" for competitive units throughout docs. A single-player entry is a "team" of one.
+    - Avoid using "player(s)" to describe competitors at the tournament/stage level; reserve "player" for team roster contexts when necessary.
+    - Reserve "participant" for the broad set of people/entities involved in a tournament (teams, officials, staff, etc.), not just competitors.
+
+Example diagram style (Graph TD) — intent and usage:
+- Use `graph TD` flowcharts to show hierarchies and classifications in a way that mirrors how users think about grouping.
+- Label nodes with meaningful, domain-focused names (e.g., "Activity: Basketball", "Domain: Sports").
+- Show classification edges with descriptive text when helpful (e.g., `-. classified in .->`).
+- For categories, show parent→child relationships to illustrate how top-level categories (e.g., Sports) contain subcategories (e.g., Darts → 501, 301) and why that helps grouping, scheduling, reporting, and eligibility.
+- For geography, show continent→country→region→city→venue to demonstrate how location hierarchies enable filtering and selection during planning and reporting.
+- Maintain a clear, professional, and neutral tone throughout. Focus on actionable guidance and practical examples. Avoid unnecessary jargon or informality.
+
+### Formatting & Accessibility
+- Use consistent Markdown syntax for headings and lists.
+- Avoid code blocks for code samples in documentation. Use diagrams instead. Exception: Mermaid fenced blocks are encouraged for diagrams (prefer `graph TD`).
+- Apply project-specific style rules. Most important MkDocs recommendations:
+  - Use clear, descriptive headings and organize content hierarchically.
+  - Keep navigation simple and intuitive.
+  - Ensure all pages have a title and metadata for searchability.
+- Use whitespace and line breaks to separate sections and improve readability.
+- Follow style and formatting standards for consistency.
+- Review for common Vale warnings (passive voice, wordiness, weasel words).
+- Prefer short, clear sentences over long, complex ones.
+- Follow accessibility best practices:
+  - Add alt text to images.
+  - Use clear, descriptive link text.
+  - Ensure sufficient color contrast and readable font sizes.
+- Format tables and diagrams for clarity:
+  - Use simple tables with clear headers and consistent alignment.
+  - Add captions or descriptions to diagrams.
+- Keep formatting simple and intuitive, especially for non-technical users. Avoid complex layouts or excessive styling.
+- Use tags and metadata for organization and searchability.
+
+### Link Management
+- Always check links for accuracy and relevance before publishing.
+- Use relative links for internal documentation to avoid broken links when moving files.
+- Prefer descriptive link text over raw URLs (e.g., "See the [Style Guide]" instead of "http://.../style-guide").
+- Regularly audit documentation for broken or outdated links.
+- Document link management practices in style guides and templates.
+
+### Content Relevance & Maintenance
+- Only add content that is relevant and necessary for users; avoid clutter and unnecessary documentation.
+- Regularly review and update content to ensure accuracy and relevance.
+- Use versioning to track changes and maintain historical records.
+- Remove or revise outdated information promptly.
+- Populate empty files and folders with meaningful content and cross-references.
+- Organize domain documentation for clarity and discoverability:
+  - Use a hierarchical folder structure to group documents by domain and subdomain.
+  - Apply consistent naming conventions for files and folders.
+  - Create and follow templates for domain documents to ensure uniformity.
+  - Link related domain documents to support navigation and context.
+
+## Link Management
+
+### Internal Links
+- Use relative paths for all internal documentation links (e.g., `[Base Entity](../foundation/base_entity.md)`)
+- Test links locally before committing to ensure they resolve correctly
+- Use descriptive link text that explains the destination or purpose
+- Avoid generic phrases like "click here" or "read more"
+
+### External Links
+- Use full URLs for external resources
+- Include link text that identifies the external source (e.g., `[MkDocs Material Documentation](https://squidfunk.github.io/mkdocs-material/)`)
+- Verify external links are stable and likely to remain available
+- Consider using archive links for important but potentially unstable resources
+
+### Cross-References
+- Link to related domain documents using clear, contextual anchor text
+- Create bidirectional links where relationships exist between domains
+- Use the `See Also` section for related links that don't fit naturally in the content
+- Maintain a consistent linking strategy across all domain documentation
+
+### Link Validation
+- Run link checking tools during pre-commit hooks
+- Regularly audit documentation for broken internal and external links
+- Update or remove outdated links promptly
+- Document any intentionally broken links (e.g., planned future content) with clear notes
+
+## Quick Reference Checklist
+
+### Before Publishing Any Documentation
+
+**Structure & Content:**
+- [ ] Starts with visible H1 title (no `title:` in front matter)
+- [ ] Includes 2-6 relevant tags in YAML front matter
+- [ ] References Base Entity for standard attributes (no explicit listing)
+- [ ] Includes comprehensive examples covering ALL attributes
+- [ ] Uses active voice and concise sentences
+- [ ] Follows domain file structure: Overview → Purpose → Structure → Example → See Also
+
+**Formatting & Style:**
+- [ ] Uses consistent Markdown syntax
+- [ ] Applies proper heading hierarchy (single H1, then H2+)
+- [ ] Includes alt text for images
+- [ ] Uses descriptive link text
+- [ ] Follows terminology conventions (teams vs. participants)
+- [ ] Uses Mermaid `graph TD` for diagrams when appropriate
+
+**Technical Requirements:**
+- [ ] Passes markdown linting (MD025, MD041 compliance)
+- [ ] Uses relative links for internal references
+- [ ] Validates all external links
+- [ ] Includes proper YAML front matter
+- [ ] Follows embedding rules (same domain = embed, different domain = UUID reference)
+
+**Final Review:**
+- [ ] Content is relevant and necessary
+- [ ] Examples use domain-relevant, descriptive values
+- [ ] Links are accurate and functional
+- [ ] Accessible to intended audience
+- [ ] Maintains professional, neutral tone
+
+## How to Use
+Use this file as a checklist when writing or reviewing documentation. For best results, follow this order:
+1. Draft content using the writing and structure guidelines.
+2. Apply formatting and accessibility rules.
+3. Check and manage links.
+4. Review for relevance and maintain content as needed.
+These instructions are designed for both human and AI authors. Link to related lessons for deeper guidance.

--- a/documents/docs/domains/code_of_conduct/README.md
+++ b/documents/docs/domains/code_of_conduct/README.md
@@ -1,119 +1,34 @@
 # Code of Conduct Domain
 
+tag: code-of-conduct, behavior, rule, template, conduct
+
 ## Overview
 
-The Code of Conduct domain defines the models and relationships for managing behavioral standards and requirements
-within the tournament system. This domain ensures a safe, respectful, and fair environment by providing clear guidelines
-for participant conduct.
+The Code of Conduct domain provides standardized behavioral frameworks and enforcement mechanisms for tournament environments. It enables consistent conduct management through template-based rules, expected behaviors, and enforcement structures that can be customized for specific contexts while maintaining core standards.
 
-## Models
+## Purpose
 
-### 1. Code of Conduct (Template Entity)
+- Enable clear, consistent behavioral standards across all tournament contexts.
+- Support template-based conduct management for reuse and customization.
+- Facilitate rule-based enforcement and positive behavior promotion.
 
-- Defines the structure and composition of a code of conduct
-- Acts as a template that can be instantiated for specific contexts (e.g., tournaments, organizations)
-- References both Rules and Expected Behaviors
-- Includes versioning for tracking changes to the template
+## Structure
 
-### 2. Expected Behavior (Entity)
+The domain consists of template entities for behavioral management and conduct enforcement:
 
-- Defines positive, aspirational standards of conduct
-- Focuses on encouraging good behavior rather than prohibiting bad behavior
-- Includes examples and rationale for each behavior
-- Can be categorized and contextualized for different scenarios
-
-### 3. Rule (Entity)
-
-- Defines mandatory, enforceable requirements
-- Includes clear consequences for violations
-- Categorized by type (e.g., Safety, Fair Play, Anti-Discrimination)
-- Specifies applicability and severity
-
-## Relationships
-
-The domain models are related as follows:
-
-1. **Code of Conduct Template**
-   - References multiple Expected Behaviors
-   - References multiple Rules
-   - Inherits from Base Entity for lifecycle management
-   - Can be instantiated for specific contexts (Tournaments, Organizations)
-
-2. **Expected Behavior**
-   - Referenced by Code of Conduct Templates
-   - Inherits from Base Entity for lifecycle management
-   - Can be associated with Tournaments and Organizations
-
-3. **Rule**
-   - Referenced by Code of Conduct Templates
-   - Inherits from Base Entity for lifecycle management
-   - Can be associated with Tournaments and Organizations
-
-All entities in this domain inherit from the Base Entity model, which provides standard attributes for tracking, status
-management, and version control.
-
-## Key Concepts
-
-1. **Template-Based Approach**
-   - Code of Conduct is a template entity
-   - Can be instantiated for different contexts
-   - Maintains version control for changes
-
-2. **Two-Tier Standards**
-   - Rules: Mandatory requirements with consequences
-   - Expected Behaviors: Positive standards to encourage
-
-3. **Lifecycle Management**
-   - All entities inherit from Base Entity
-   - Includes standard attributes for tracking and status management
-   - Supports audit trails and version control
-
-## Usage Guidelines
-
-1. **Creating a Code of Conduct**
-   - Start with the template
-   - Select appropriate Rules and Expected Behaviors
-   - Customize for specific context
-   - Version appropriately
-
-2. **Managing Rules**
-   - Keep language clear and specific
-   - Define concrete consequences
-   - Categorize appropriately
-   - Consider applicability
-
-3. **Defining Expected Behaviors**
-   - Focus on positive standards
-   - Provide clear examples
-   - Include rationale
-   - Consider context
-
-## Related Domains
-
-- **Identity Domain**: For managing participant roles and responsibilities
-- **Tournament Domain**: For applying codes of conduct to specific events
-- **Organization Domain**: For organizational-level conduct standards
-
-## References
-
-- [ISO 26000:2010 - Guidance on social responsibility](https://www.iso.org/standard/42546.html) - Standard for
-
-  organizational conduct and social responsibility
-
-- [ISO 37301 — Compliance management systems (ISO official page)](https://www.iso.org/standard/75080.html) - Standard for compliance
-
-   and conduct management
-
-- [Domain-Driven Design: Tackling Complexity in the Heart of Software](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215)
-
-  by Eric Evans - Template Entity and domain modeling patterns
+| Entity | Description |
+|--------|-------------|
+| [Code of Conduct](code_of_conduct.md) | Template defining complete behavioral frameworks with rules and expected behaviors. |
+| [Expected Behavior](expected_behavior.md) | Template for positive, aspirational conduct standards that promote good behavior. |
+| [Rule](rule.md) | Template for mandatory, enforceable requirements with clear consequences for violations. |
 
 ## See Also
 
-- [Code Of Conduct](../code_of_conduct/code_of_conduct.md)
-- [Expected Behavior](../code_of_conduct/expected_behavior.md)
-- [Rule](../code_of_conduct/rule.md)
-- [Role](../identity/role/role.md)
-- [Tournament](../tournament/tournament.md)
-- [Organization](../organization/organization.md)
-- [Safety](../safety/safety.md)
+- [Code of Conduct](code_of_conduct.md)
+- [Expected Behavior](expected_behavior.md)
+- [Rule](rule.md)
+- [Identity Domain](../identity/README.md)
+- [Tournament Domain](../tournament/README.md)
+- [Organization Domain](../organization/README.md)
+- [Safety Domain](../safety/README.md)
+- [Foundation Domain](../foundation/README.md)

--- a/documents/docs/domains/code_of_conduct/README.md
+++ b/documents/docs/domains/code_of_conduct/README.md
@@ -1,6 +1,13 @@
-# Code of Conduct Domain
+---
+tags:
+  - code-of-conduct
+  - behavior
+  - rule
+  - template
+  - conduct
+---
 
-tag: code-of-conduct, behavior, rule, template, conduct
+# Code of Conduct Domain
 
 ## Overview
 

--- a/documents/docs/domains/code_of_conduct/code_of_conduct.md
+++ b/documents/docs/domains/code_of_conduct/code_of_conduct.md
@@ -1,65 +1,92 @@
-# **Code of Conduct** (Data Model - Template Entity)
-
-## **Introduction**
-
-A **Code of Conduct** Entity Template defines the enforceable standards and positive expectations for conduct within a
-given context (e.g., Tournament, Organization). It is composed of references to 🚨 **BROKEN:** 🚨 **BROKEN:**
-[Rule](../discipline/activity/variation/rule.md) entities (mandatory, enforceable requirements) and
-[Expected Behavior](../code_of_conduct/expected_behavior.md) entities (positive standards), ensuring a
-safe, respectful, and fair environment.
-
-Guidelines, which are non-binding recommendations, are not referenced directly in the Code of Conduct but may be
-provided separately.
-
-It inherits properties from the [Base Entity](../foundation/base_entity.md).
-
+---
+tags:
+  - code-of-conduct
+  - behavior
+  - template
+  - rule
+  - conduct
 ---
 
-## **Attributes**
+# Code of Conduct (Template Entity)
 
-| Attribute              | Description                                                                                                                                               | Type       | Required | Notes / Example                                                                |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------- | ------------------------------------------------------------------------------ |
-| **Title**              | The official name or title of the Code of Conduct template.                                                                                               | String     | Yes      | Example: `Fair Play and Respect Policy`, `Standard Tournament Code of Conduct` |
-| **Version**            | A version identifier (e.g., date or number) for this specific template revision.                                                                          | String     | Optional | Example: `v2.1`, `2024-07-28`                                                  |
-| **Introduction**       | Optional introductory text (Markdown) to set the context, purpose, or spirit of the Code of Conduct.                                                      | Text       | Optional | Example: "This document outlines the behavior expected of all participants..." |
-| **Applicability**      | Describes the intended scope or context (e.g., Tournament, Organization, Event).                                                                          | String     | Optional | Example: `"Tournament - General"`, `"Youth Events"`                            |
-| **Expected Behaviors** | List of references (by ID) to the **[Expected Behavior](../code_of_conduct/expected_behavior.md)** Entities included in this template.      | List[UUID] | Optional | Example: `["eb-a1b2c3d4-e5f6-4890-1234-567890abc111"]`                         |
-| **Rules**              | List of references (by ID) to the **[Rule](../code_of_conduct/rule.md)** Entities included in this template.  | List[UUID] | Optional | Example: `["rule-a1b2c3d4-e5f6-4890-1234-567890abc222"]`                       |
+## Overview
 
----
+A Code of Conduct is a template entity that defines comprehensive behavioral frameworks for tournament environments. It combines mandatory rules and positive expected behaviors to create complete conduct standards that can be instantiated and customized for specific contexts while maintaining core behavioral principles.
 
-## **Considerations**
+## Purpose
 
-- **Enforceability:** Only Rules and Expected Behaviors are referenced to ensure all standards are actionable and
+- Enable standardized behavioral frameworks across different tournament contexts and organizations.
+- Support template-based conduct management that balances consistency with customization needs.
+- Facilitate comprehensive conduct standards through integrated rules and expected behaviors.
 
-  enforceable.
+## Structure
 
-- **Clarity:** Guidelines are kept separate to avoid confusion between mandatory requirements and recommendations.
-- **Template vs. Instance:** This model defines the _template_. The actual Code of Conduct applied to a specific context
+This template entity includes standard attributes from the [Base Entity](../foundation/base_entity.md).
 
-  is created by copying this template's definition into the target context.
+### Attributes
 
-- **Versioning:** The `Version` attribute tracks changes to the template composition itself.
+| Attribute | Description | Type | Required | Example |
+|-----------|-------------|------|----------|---------|
+| Title | Official name for the code of conduct template | String | Yes | Fair Play and Respect Policy, Standard Tournament Code of Conduct |
+| Version | Version identifier for template tracking | String | Optional | v2.1, 2024-07-28 |
+| Introduction | Introductory text explaining purpose and context | Text | Optional | This document outlines the behavior expected of all participants... |
+| Applicability | Intended scope or context for the template | String | Optional | Tournament - General, Youth Events, Professional Competition |
+| Expected Behaviors | List of positive behavioral standards | List[Expected Behavior] | Optional | Embedded expected behavior entities |
+| Rules | List of mandatory requirements with consequences | List[Rule] | Optional | Embedded rule entities |
 
----
+## Example
 
-## References
+### Example 1: Youth Tournament Code of Conduct
 
-- [ISO 26000:2010 - Guidance on social responsibility](https://www.iso.org/standard/42546.html) - Standard for
+```mermaid
+graph TD
+    COC[Code of Conduct: Youth Soccer Standards]
+    COC --> T[Title: Youth Soccer Code of Conduct]
+    COC --> V[Version: v1.2]
+    COC --> I[Introduction: Guidelines for fair play in youth soccer]
+    COC --> A[Applicability: Youth Soccer Tournaments]
+    COC --> EB[Expected Behaviors]
+    COC --> R[Rules]
+    
+    EB --> EB1[Respect for Officials]
+    EB --> EB2[Good Sportsmanship]
+    EB --> EB3[Supportive Team Spirit]
+    
+    R --> R1[No Physical Contact with Officials]
+    R --> R2[No Abusive Language]
+    R --> R3[Attend All Team Meetings]
+```
 
-  organizational conduct and social responsibility
+This example illustrates a complete youth soccer code of conduct template showing all attributes. The Title identifies the specific context (Youth Soccer), Version tracks template evolution (v1.2), Introduction provides context for the document's purpose, and Applicability clearly defines the scope (Youth Soccer Tournaments). The template includes three Expected Behaviors that promote positive conduct (respect, sportsmanship, team spirit) and three Rules with enforceable requirements (no physical contact, no abuse, attendance). This comprehensive approach ensures youth tournaments have both aspirational standards and clear boundaries, helping organizers maintain safe, positive environments while teaching good conduct principles.
 
-- [ISO 37301 — Compliance management systems (ISO official page)](https://www.iso.org/standard/75080.html) - Standard for compliance
+### Example 2: Professional Competition Code of Conduct
 
-  and conduct management
+```mermaid
+graph TD
+    COC[Code of Conduct: Professional Standards]
+    COC --> T[Title: Professional Competition Code]
+    COC --> V[Version: v2.0]
+    COC --> I[Introduction: Professional conduct expectations]
+    COC --> A[Applicability: Professional Tournaments]
+    COC --> EB[Expected Behaviors]
+    COC --> R[Rules]
+    
+    EB --> EB1[Professional Communication]
+    EB --> EB2[Media Responsibility]
+    
+    R --> R1[Anti-Doping Compliance]
+    R --> R2[Equipment Regulations]
+    R --> R3[Time Management Requirements]
+    R --> R4[Conflict of Interest Disclosure]
+```
 
-- [Event Management Body of Knowledge (EMBOK)](https://www.embok.org/index.php/embok-model) - Event management standards
-
-  including conduct guidelines
+This example demonstrates a professional-level code of conduct template with more complex requirements. The Title reflects the professional context, Version indicates a major update (v2.0), Introduction sets professional expectations, and Applicability targets professional competition settings. The Expected Behaviors focus on professional communication and media responsibilities appropriate for high-level competition, while Rules address critical professional requirements including anti-doping compliance, equipment standards, time management, and conflict disclosure. This template enables tournament organizers to maintain professional standards while providing clear frameworks for enforcement and education.
 
 ## See Also
 
-- [Expected Behavior](../code_of_conduct/expected_behavior.md)
-- [Rule](../code_of_conduct/rule.md)
-
----
+- [Expected Behavior](expected_behavior.md)
+- [Rule](rule.md)
+- [Code of Conduct Domain](README.md)
+- [Tournament Domain](../tournament/README.md)
+- [Organization Domain](../organization/README.md)
+- [Safety Domain](../safety/README.md)

--- a/documents/docs/domains/code_of_conduct/expected_behavior.md
+++ b/documents/docs/domains/code_of_conduct/expected_behavior.md
@@ -1,86 +1,72 @@
-# **Expected Behavior** (Data Model - Template Entity)
-
-## **Introduction**
-
-An **Expected Behavior** Entity defines a positive, aspirational standard of conduct for participants, officials,
-spectators, or other stakeholders. Expected Behaviors are referenced by the
-[Code of Conduct](../code_of_conduct/code_of_conduct.md) to promote a safe, respectful, and inclusive
-environment. They complement Rules by describing the positive actions and attitudes that are encouraged.
-
-It inherits properties from the [Base Entity](../foundation/base_entity.md).
-
-As a Template Entity, it possesses a unique identity and lifecycle, managed according to the [Base Entity](../foundation/base_entity.md), with additional template-specific attributes for versioning and reuse.
-
+---
+tags:
+  - expected-behavior
+  - conduct
+  - template
+  - positive
+  - behavior
 ---
 
-## **Attributes**
+# Expected Behavior (Template Entity)
 
-**Note:** This Template Entity includes the standard attributes (`ID`, `Status`, `CreatedAt`, `LastUpdatedAt`) defined in the [Base Entity](../foundation/base_entity.md).
+## Overview
 
-| Attribute         | Description                                        | Type   | Required | Notes / Example                                |
-| ----------------- | -------------------------------------------------- | ------ | -------- | ---------------------------------------------- |
-| **Title**         | Short, descriptive name for the expected behavior. | String | Yes      | `Sportsmanship`                                |
-| **Description**   | Detailed explanation of the expected behavior.     | Text   | Yes      | `Treat all participants with respect...`       |
-| **Category**      | Classification of the behavior.                    | String | No       | `Respect`, `Sportsmanship`, `Professionalism`  |
-| **Applicability** | Context where the behavior applies.                | String | No       | `All Participants`, `Officials`, `Spectators`  |
-| **Rationale**     | Why this behavior is important.                    | Text   | No       | `Promotes fair play and positive environment.` |
+An Expected Behavior is a template entity that defines positive, aspirational conduct standards for tournament participants. It focuses on encouraging good behavior and creating positive environments rather than prohibiting actions, providing clear examples and rationale for why specific behaviors are valued.
 
----
+## Purpose
 
-## **Relationships**
+- Enable standardized positive behavioral expectations across tournament environments.
+- Support template-based behavior management that promotes good conduct through clear examples.
+- Facilitate aspirational standards that complement mandatory rules with positive guidance.
 
-- Referenced by [Code of Conduct](../code_of_conduct/code_of_conduct.md) as a positive standard.
-- May be associated with [Rule](../discipline/activity/variation/rule.md) for context.
-- May be linked to specific events, matches, or participant types.
+## Structure
 
----
+This template entity includes standard attributes from the [Base Entity](../foundation/base_entity.md).
 
-## **Considerations**
+### Attributes
 
-- **Template Nature:** This template defines a standard expected behavior type. Instance-specific variations or customizations
+| Attribute | Description | Type | Required | Example |
+|-----------|-------------|------|----------|---------|
+| Title | Short, descriptive name for the expected behavior | String | Yes | Sportsmanship, Respect for Officials, Team Support |
+| Description | Detailed explanation of the expected behavior | Text | Yes | Treat all participants with respect and dignity... |
+| Category | Classification of the behavior type | String | No | Respect, Sportsmanship, Professionalism, Communication |
+| Applicability | Context where the behavior applies | String | No | All Participants, Officials, Spectators, Team Members |
+| Rationale | Explanation of why this behavior is important | Text | No | Promotes fair play and positive tournament environment |
 
-  belong on the copied instance within its specific context (e.g., a specific tournament's implementation).
+## Example
 
-- **Copy Mechanism:** The process of copying this template definition into a target context (like a specific tournament)
+### Example 1: Sportsmanship Behavior Template
 
-  needs to be handled by application logic.
+```mermaid
+graph TD
+    EB[Expected Behavior: Sportsmanship]
+    EB --> T[Title: Good Sportsmanship]
+    EB --> D[Description: Demonstrate respect for opponents and fair play]
+    EB --> C[Category: Sportsmanship]
+    EB --> A[Applicability: All Team Members]
+    EB --> R[Rationale: Creates positive competitive environment]
+```
 
-- **Template Management:**
-  - Templates should be curated and maintained by compliance administrators
-  - New templates can be added based on organizational values and cultural requirements
-  - Templates should be reviewed periodically for clarity and relevance
-- **Aspirational:** Expected Behavior templates describe what is encouraged, not just what is required.
-- **Clarity:** Use clear, positive language in behavior templates.
-- **Contextualization:** Specify where and to whom the behavior template applies.
-- **Versioning:** Track changes for audit and communication.
-- **Customization Balance:**
-  - Templates provide structure while allowing personalization
-  - Customizations should not break the fundamental behavior structure
-  - System should support both template-based and fully custom expected behaviors
+This example shows a complete sportsmanship expected behavior template covering all attributes. The Title provides a clear, recognizable name (Good Sportsmanship), while the Description gives specific guidance about respecting opponents and maintaining fair play standards. The Category classification (Sportsmanship) helps organizers group related behaviors, and Applicability clearly defines who should follow this standard (All Team Members). The Rationale explains why this behavior matters - creating positive competitive environments that enhance the tournament experience for everyone involved and promote the values of fair competition.
 
----
+### Example 2: Communication Behavior Template
 
-## References
+```mermaid
+graph TD
+    EB[Expected Behavior: Professional Communication]
+    EB --> T[Title: Respectful Communication]
+    EB --> D[Description: Use appropriate language and tone in all interactions]
+    EB --> C[Category: Communication]
+    EB --> A[Applicability: All Participants]
+    EB --> R[Rationale: Maintains professional tournament atmosphere]
+```
 
-- [ISO 26000:2010 - Guidance on social responsibility](https://www.iso.org/standard/42546.html) - Standard for
-
-  organizational conduct and social responsibility
-
-- [Event Management Body of Knowledge (EMBOK)](https://www.embok.org/index.php/embok-model) - Event management standards
-
-  including conduct guidelines
-
-- [Domain-Driven Design: Tackling Complexity in the Heart of Software](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215)
-
-  by Eric Evans - Entity pattern reference
+This example demonstrates a communication-focused expected behavior template with all required attributes. The Title identifies the specific behavior area (Respectful Communication), and the Description provides actionable guidance about language and tone expectations. The Category (Communication) enables organizers to group communication-related behaviors together for training and enforcement purposes. Applicability extends to All Participants, ensuring comprehensive coverage, while the Rationale explains the importance of maintaining professional tournament atmospheres that respect all participants and create inclusive environments conducive to fair competition.
 
 ## See Also
 
-- [Code Of Conduct](../code_of_conduct/code_of_conduct.md)
-- [Rule](../code_of_conduct/rule.md)
-- [Code_Of_Conduct README](../code_of_conduct/README.md)
-- [Rule](../discipline/activity/variation/rule.md)
-- [Safety](../safety/safety.md)
-- [Role](../identity/role/role.md)
-
----
+- [Code of Conduct](code_of_conduct.md)
+- [Rule](rule.md)
+- [Code of Conduct Domain](README.md)
+- [Identity Domain](../identity/README.md)
+- [Safety Domain](../safety/README.md)

--- a/documents/docs/domains/code_of_conduct/rule.md
+++ b/documents/docs/domains/code_of_conduct/rule.md
@@ -1,59 +1,75 @@
-# **Rule** (Data Model - Template Entity)
-
-## **Introduction**
-
-A **Rule** Entity defines a mandatory, enforceable requirement or prohibition within the context of a tournament, event,
-or organization. Rules are referenced by the [Code of Conduct](../code_of_conduct/code_of_conduct.md) and
-are the basis for disciplinary action if violated. Each rule is specific, actionable, and includes clear consequences
-for non-compliance.
-
-It inherits properties from the [Base Entity](../foundation/base_entity.md).
-
-As a Template Entity, it possesses a unique identity and lifecycle, managed according to the [Base Entity](../foundation/base_entity.md), with additional template-specific attributes for versioning and reuse.
-
+---
+tags:
+  - rule
+  - conduct
+  - template
+  - enforcement
+  - mandatory
 ---
 
-## **Attributes**
+# Rule (Template Entity)
 
-**Note:** This Template Entity includes the standard attributes (`ID`, `Status`, `CreatedAt`, `LastUpdatedAt`) defined in the [Base Entity](../foundation/base_entity.md).
+## Overview
 
-| Attribute         | Description                           | Type   | Required | Notes / Example                               |
-| ----------------- | ------------------------------------- | ------ | -------- | --------------------------------------------- |
-| **Title**         | Short, descriptive name for the rule. | String | Yes      | `No Physical Contact with Officials`          |
-| **Description**   | Detailed explanation of the rule.     | Text   | Yes      | `Participants must not physically contact...` |
-| **Category**      | Classification of the rule.           | String | No       | `Safety`, `Fair Play`, `Anti-Discrimination`  |
-| **Applicability** | Context where the rule applies.       | String | No       | `Tournament`, `Match`, `All Participants`     |
-| **Consequence**   | Action taken if the rule is violated. | Text   | Yes      | `Immediate disqualification`                  |
-| **Severity**      | Severity of violation.                | String | No       | `Minor`, `Major`, `Critical`                  |
+A Rule is a template entity that defines mandatory, enforceable requirements for tournament participants. It specifies clear prohibitions or obligations with defined consequences for non-compliance, providing the enforcement backbone for codes of conduct and ensuring consistent behavioral standards across tournament environments.
 
----
+## Purpose
 
-## **Considerations**
+- Enable standardized mandatory requirements with clear enforcement mechanisms.
+- Support template-based rule management that ensures consistent consequences and applicability.
+- Facilitate enforceable standards that complement positive expected behaviors with clear boundaries.
 
-- **Enforceability:** Rule templates must be clear, actionable, and have defined consequences.
-- **Clarity:** Avoid ambiguity in rule template language.
-- **Contextualization:** Specify where and to whom the rule template applies.
+## Structure
 
----
+This template entity includes standard attributes from the [Base Entity](../foundation/base_entity.md).
 
-## References
+### Attributes
 
-- [ISO 26000:2010 - Guidance on social responsibility](https://www.iso.org/standard/42546.html) - Standard for
+| Attribute | Description | Type | Required | Example |
+|-----------|-------------|------|----------|---------|
+| Title | Short, descriptive name for the rule | String | Yes | No Physical Contact with Officials, Equipment Regulations |
+| Description | Detailed explanation of the rule requirement | Text | Yes | Participants must not physically contact tournament officials... |
+| Category | Classification of the rule type | String | No | Safety, Fair Play, Anti-Discrimination, Equipment |
+| Applicability | Context where the rule applies | String | No | Tournament, Match, All Participants, Team Members |
+| Consequence | Action taken if the rule is violated | Text | Yes | Immediate disqualification, Warning, Point penalty |
+| Severity | Severity level of rule violations | String | No | Minor, Major, Critical, Automatic Disqualification |
 
-  organizational conduct and social responsibility
+## Example
 
-- [ISO 37301 — Compliance management systems (ISO official page)](https://www.iso.org/standard/75080.html) - Standard for compliance
+### Example 1: Safety Rule Template
 
-  and rule enforcement
+```mermaid
+graph TD
+    R[Rule: No Physical Contact]
+    R --> T[Title: No Physical Contact with Officials]
+    R --> D[Description: Participants must never physically contact tournament officials]
+    R --> C[Category: Safety]
+    R --> A[Applicability: All Tournament Participants]
+    R --> CN[Consequence: Immediate disqualification from tournament]
+    R --> S[Severity: Critical]
+```
 
-- [Event Management Body of Knowledge (EMBOK)](https://www.embok.org/index.php/embok-model) - Event management standards
+This example illustrates a critical safety rule template with all attributes clearly defined. The Title provides immediate recognition of the rule's focus (No Physical Contact with Officials), while the Description gives unambiguous guidance about the prohibited behavior. The Category classification (Safety) helps organizers group safety-related rules for training and enforcement protocols. Applicability ensures comprehensive coverage (All Tournament Participants), and the Consequence specifies immediate and severe action (disqualification) that matches the Critical severity level. This comprehensive approach enables tournament organizers to maintain safe environments with clear, enforceable boundaries that protect officials and maintain order.
 
-  including rule enforcement
+### Example 2: Equipment Rule Template
+
+```mermaid
+graph TD
+    R[Rule: Equipment Standards]
+    R --> T[Title: Approved Equipment Only]
+    R --> D[Description: Teams must use only tournament-approved equipment]
+    R --> C[Category: Equipment]
+    R --> A[Applicability: Team Members]
+    R --> CN[Consequence: Equipment confiscation and warning]
+    R --> S[Severity: Minor]
+```
+
+This example demonstrates an equipment-focused rule template covering all required attributes. The Title clearly identifies the equipment requirement (Approved Equipment Only), and the Description provides specific guidance about tournament-approved equipment usage. The Category (Equipment) enables organizers to group equipment-related rules for consistent enforcement and equipment management protocols. Applicability targets Team Members specifically, while the Consequence outlines proportionate action (confiscation and warning) that aligns with the Minor severity classification. This balanced approach helps organizers maintain equipment standards while providing educational opportunities for teams to understand and comply with equipment requirements.
 
 ## See Also
 
-- [Code Of Conduct](../code_of_conduct/code_of_conduct.md)
-- [Expected Behavior](../code_of_conduct/expected_behavior.md)
-- [Tournament Rule](../tournament/rule.md)
-
----
+- [Code of Conduct](code_of_conduct.md)
+- [Expected Behavior](expected_behavior.md)
+- [Code of Conduct Domain](README.md)
+- [Safety Domain](../safety/README.md)
+- [Discipline Domain](../discipline/README.md)


### PR DESCRIPTION
## Summary

This PR revises the Code of Conduct domain to follow the updated documentation standards established in recent domains like Classification and Discipline.

## Changes Made

### Documentation Standards
- **Added missing documentation-style-link.instructions.md** file with comprehensive guidelines
- **Restructured all files** to follow: Overview → Purpose → Structure → Example → See Also

### Code of Conduct Domain Files
- **README.md**: Updated to match current domain format (Classification/Discipline pattern)
- **code_of_conduct.md**: Added proper YAML tags, comprehensive examples with Mermaid diagrams
- **expected_behavior.md**: Restructured with complete attribute coverage in examples
- **rule.md**: Enhanced with examples demonstrating ALL template entity attributes

### Technical Improvements
- **Fixed broken internal links** (removed invalid references)
- **Added proper YAML front matter** with relevant tags for searchability
- **Implemented embedding rules** for same-domain references
- **Added comprehensive Mermaid diagrams** (graph TD format) with explanatory paragraphs
- **Ensured all examples demonstrate ALL attributes** from the Structure section

### Quality Assurance
- ✅ MkDocs build successful (our changes process correctly)
- ✅ Mermaid diagrams render properly (2 diagrams per entity file)
- ✅ All internal links validated
- ✅ Follows embedding rules (same domain = embed, different domain = UUID)
- ✅ Professional tone and domain-relevant examples

## Testing

- MkDocs build passes for our changes
- All Mermaid diagrams detected and processed correctly
- No broken links introduced by our changes

## Checklist

- [x] Follows proper GitHub workflow (feature branch, focused commits)
- [x] Uses current documentation standards from Classification/Discipline domains
- [x] Includes comprehensive examples covering ALL attributes
- [x] Proper YAML front matter with relevant tags
- [x] Mermaid diagrams with explanatory paragraphs
- [x] Fixed broken internal links
- [x] Maintains professional, neutral tone

This brings the Code of Conduct domain up to current documentation standards and provides a solid foundation for behavioral management in tournament environments.