### PR TITLE
docs: Convert remaining identity domain files to new YAML front matter format (#30)

### DIFF
--- a/documents/docs/domains/identity/account/setting/scope.md
+++ b/documents/docs/domains/identity/account/setting/scope.md
@@ -1,26 +1,32 @@
-# **Scope** (Data Model - Template Entity)
+---
+tags:
+- identity
+- account
+- scope
+- template-entity
+- configuration
+---
 
-## **Introduction**
+# Scope (Template Entity)
 
-A **Scope** Entity Template defines the context or domain where settings and configurations apply within the Tournament
-Organizer system. It provides a standardized way to manage and organize settings across different contexts such as
-tournaments, disciplines, teams, or global system settings.
+## Introduction
 
-As a Template Entity, it possesses a unique identity and lifecycle, managed according to the [Base Entity](../../../foundation/base_entity.md). When used, its
-definition is typically **copied** into the target context, allowing for potential modifications while maintaining the
-original template's structure.
+A **Scope** Entity Template defines the context or domain where settings and configurations apply within the
+Tournament Organizer system. It provides a standardized way to manage and organize settings across different contexts
+such as tournaments, disciplines, teams, or global system settings.
 
-_(For a guide on how scopes are used in settings management, see the
-<!-- [User Guide: Account Settings](# ../user_guide/ (TODO: Create user guide) -->))._
+As a Template Entity, it possesses a unique identity and lifecycle, managed according to the
+[Base Entity](../../../foundation/base_entity.md). When used, its definition is typically **copied** into the target
+context, allowing for potential modifications while maintaining the original template's structure.
 
 It inherits properties from the [Base Entity](../../../foundation/base_entity.md).
 
 ---
 
-## **Attributes**
+## Attributes
 
 **Note:** This Entity Template includes the standard attributes (`ID`, `Status`, `CreatedAt`, `LastUpdatedAt`) defined
-in the .
+in the [Base Entity](../../../foundation/base_entity.md).
 
 | Attribute       | Description                                                  | Type       | Required | Notes / Example                                                                                     |
 | --------------- | ------------------------------------------------------------ | ---------- | -------- | --------------------------------------------------------------------------------------------------- |
@@ -31,13 +37,11 @@ in the .
 
 ---
 
-## **Relationships**
+## Relationships
 
 - A `Scope` Template can be referenced by:
 
-- 🚨 **BROKEN:** 🚨 **BROKEN:** [Setting](../../role/permission/README.md) 🚨 🚨 entities for
-
-    defining where settings apply
+- [Setting](setting.md) entities for defining where settings apply
 
 - Account configurations for user-specific settings
 - System configurations for global settings
@@ -51,7 +55,7 @@ in the .
 
 ---
 
-## **Considerations**
+## Considerations
 
 - **Template Usage:** Serves as a reusable component for defining setting contexts across the system
 - **Copy Mechanism:** When instantiated, creates a new scope record with its own identity and context

--- a/documents/docs/domains/identity/account/setting/setting.md
+++ b/documents/docs/domains/identity/account/setting/setting.md
@@ -1,49 +1,57 @@
-# **Setting** (Data Model - Template Entity)
+---
+tags:
+- identity
+- account
+- setting
+- template-entity
+- configuration
+---
 
-## **Introduction**
+# Setting (Template Entity)
 
-A **Setting** is an **Entity Template** that defines a configurable parameter or preference that can be applied to
-various entities in the system. It provides a standardized way to manage and apply configuration values across different
-contexts.
+## Introduction
 
-When this template is used (e.g., within a specific context), its definition is applied according to the
+A **Setting** is a **Template Entity** that defines a configurable parameter or preference that can be applied to
+various entities in the system. It provides a standardized way to manage and apply configuration values across
+different contexts.
 
-<!-- [copying mechanism](# ../concepts/ddd_concepts.md (TODO: Create DDD concepts) -->#entity-template).
-
-_(For a guide on how settings fit into the overall structure, see the
-<!-- [User Guide: Setting](# ../user_guide/ (TODO: Create user guide) -->))._
+When this template is used (e.g., within a specific context), its definition is applied according to the Base Entity
+framework.
 
 It inherits properties from the [Base Entity](../../../foundation/base_entity.md).
 
+As a Template Entity, it possesses a unique identity and lifecycle, managed according to the
+[Base Entity](../../../foundation/base_entity.md), with additional template-specific attributes for versioning and
+reuse.
+
 ---
 
-## **Attributes**
+## Attributes
 
-**Note:** This Entity includes the standard attributes (`ID`, `Status`, `CreatedAt`, `LastUpdatedAt`) defined in the [Base Entity](../../../foundation/base_entity.md).
+**Note:** This Template Entity includes the standard attributes (`ID`, `Status`, `CreatedAt`, `LastUpdatedAt`)
+defined in the [Base Entity](../../../foundation/base_entity.md).
 
 | Attribute       | Description                                                                                                                                                                             | Type         | Required | Notes / Example                                                                                         |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | -------- | ------------------------------------------------------------------------------------------------------- |
 | **Group**       | Logical grouping of the setting template (e.g., `Notifications`, `Privacy`, `UI`).                                                                                                      | String       | Yes      | Example: `Notifications`                                                                                |
-| **Name**        | Machine-readable key for the setting template (e.g., `email_../match_system/match_tiebreaker.md`).                                                                                                          | String       | Yes      | Example: `email_../match_system/match_tiebreaker.md`                                                                        |
+| **Name**        | Machine-readable key for the setting template (e.g., `email_notifications`).                                                                                                          | String       | Yes      | Example: `email_notifications`                                                                         |
 | **Description** | Optional: Human-readable description of the setting template's purpose.                                                                                                                 | String       | Optional | Example: `Enable email reminders before matches start.`                                                 |
-| **Scope**       | Reference (by ID) to the 🚨 **BROKEN:** 🚨 **BROKEN:** 🚨 **BROKEN:** [Scope](../../role/permission/README.md) 🚨 🚨 🚨 entity that defines where this setting applies. | UUID         | No       | Example: `a1b2c3d4-e5f6-7890-1234-567890abc999`                                                         |
+| **Scope**       | Reference (by ID) to the [Scope](scope.md) entity that defines where this setting applies. | UUID         | No       | Example: `a1b2c3d4-e5f6-7890-1234-567890abc999`                                                         |
 | **Values**      | Represents default value(s) in the template context, or the user's chosen value(s) when embedded in the Account document.                                                               | List[String] | Yes      | Example (Template Default): `["true"]`. Example (Instance): `["dark", "compact"]`. Stored as String(s). |
 
 ---
 
-## **Relationships**
+## Relationships
 
 - A `Setting` (Template) can be associated with multiple entities through the `Apply To` attribute.
 - It references a **[Setting Type](../../../foundation/base_entity.md)** that defines its behavior and validation rules.
-- It references a **🚨 **BROKEN:** 🚨 **BROKEN:** 🚨 **BROKEN:**
-
-  [Scope](../../role/permission/README.md) 🚨 🚨 🚨** entity that defines where this setting applies.
+- It references a **[Scope](scope.md)** entity that defines where this setting applies.
 
 - This template is designed to be **copied** when used within a specific context.
 
 ---
 
-## **Considerations**
+## Considerations
 
 - **Dual Purpose (Template & Instance):** This model structure defines both the setting _template_ (managed by admins)
 

--- a/documents/docs/domains/identity/profile/animal.md
+++ b/documents/docs/domains/identity/profile/animal.md
@@ -1,17 +1,26 @@
-# **Animal Profile** (Data Model – Entity)
+---
+tags:
+- identity
+- profile
+- animal
+- entity
+- participant
+---
 
-## **Introduction**
+# Animal Profile (Entity)
+
+## Introduction
 
 The **Animal Profile** Entity inherits from the [Base Profile](base_profile.md) and
 represents an animal participant or resource within Tournament Organizer. It includes only the most essential
 animal-specific attributes and relationships, with all context-specific roles (handler, trainer, etc.) managed elsewhere
 in the system.
 
-It inherits properties from the [Base Entity](../../foundation/README.md).
+It inherits properties from the [Base Entity](../../foundation/base_entity.md).
 
 ---
 
-## **Additional Attributes**
+## Additional Attributes
 
 **Note:** This entity inherits all attributes from [Base Profile](base_profile.md).
 
@@ -27,7 +36,7 @@ It inherits properties from the [Base Entity](../../foundation/README.md).
 
 ---
 
-## **Relationships**
+## Relationships
 
 - Inherits all relationships from [Base Profile](base_profile.md).
 - Additional relationships specific to Animal Profile:
@@ -36,7 +45,7 @@ It inherits properties from the [Base Entity](../../foundation/README.md).
 
 ---
 
-## **Considerations**
+## Considerations
 
 - Inherits all considerations from [Base Profile](base_profile.md).
 - Only the owner is tracked at the profile level; all other roles are managed in team/event/assignment contexts.

--- a/documents/docs/domains/identity/profile/art.md
+++ b/documents/docs/domains/identity/profile/art.md
@@ -1,8 +1,17 @@
-# **Art Profile** (Data Model – Entity)
+---
+tags:
+- identity
+- profile
+- art
+- entity
+- asset
+---
 
-## **Introduction**
+# Art Profile (Entity)
 
-The **Art Profile** Entity inherits from the [Base Profile](../../identity/profile/base_profile.md) and
+## Introduction
+
+The **Art Profile** Entity inherits from the [Base Profile](base_profile.md) and
 represents an art asset, identity, or resource within Tournament Organizer. It adds art-specific attributes and
 relationships, such as type, artist, year, and owner.
 
@@ -10,34 +19,34 @@ It inherits properties from the [Base Entity](../../foundation/base_entity.md).
 
 ---
 
-## **Additional Attributes**
+## Additional Attributes
 
-**Note:** This entity inherits all attributes from [Base Profile](../../identity/profile/base_profile.md).
+**Note:** This entity inherits all attributes from [Base Profile](base_profile.md).
 
 | Attribute               | Description                                         | Type            | Required | Notes / Example                                                                                                                 |
 | ----------------------- | --------------------------------------------------- | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | **Type**                | The type of art                                     | String          | Yes      | `"Painting"`, `"Sculpture"`, `"Poster"`                                                                                         |
 | **Artist**              | The artist or creator of the art                    | String          | No       | `"Van Gogh"`, `"Banksy"`                                                                                                        |
 | **Year**                | The year the art was created                        | Integer         | No       | `2021`                                                                                                                          |
-| **Owner**               | Reference to the human profile of the owner         | UUID            | No       | Links to [Human Profile](../../identity/profile/human.md)                                                            |
+| **Owner**               | Reference to the human profile of the owner         | UUID            | No       | Links to [Human Profile](human.md)                                                            |
 | **Provenance**          | Reference to provenance or ownership history entity | UUID            | No       | Links to Provenance <!-- TODO: Create provenance model --> |
 | **Exhibition History**  | List of exhibitions or competitions entered         | List[UUID]      | No       | Links to Exhibition <!-- TODO: Create exhibition model -->   |
 | **Appraisal/Valuation** | Reference to appraisal or valuation entity          | UUID            | No       | Links to Appraisal <!-- TODO: Create appraisal model -->     |
 
 ---
 
-## **Relationships**
+## Relationships
 
-- Inherits all relationships from [Base Profile](../../identity/profile/base_profile.md).
+- Inherits all relationships from [Base Profile](base_profile.md).
 - Additional relationships specific to Art Profile:
 
-- [Human Profile](../../identity/profile/human.md) (Owner)
+- [Human Profile](human.md) (Owner)
 
 ---
 
-## **Considerations**
+## Considerations
 
-- Inherits all considerations from [Base Profile](../../identity/profile/base_profile.md).
+- Inherits all considerations from [Base Profile](base_profile.md).
 - Art profiles may be linked to human owners, teams, or organizations.
 
 ---
@@ -56,9 +65,9 @@ It inherits properties from the [Base Entity](../../foundation/base_entity.md).
 
 ## See Also
 
-- [Base Profile](../../identity/profile/base_profile.md)
-- [Human](../../identity/profile/human.md)
-- [Identity README](../../identity/README.md)
+- [Base Profile](base_profile.md)
+- [Human](human.md)
+- [Identity README](../README.md)
 - [Business README](../../README.md)
 
 ---

--- a/documents/docs/domains/identity/profile/computer.md
+++ b/documents/docs/domains/identity/profile/computer.md
@@ -1,8 +1,17 @@
-# **Computer Profile** (Data Model – Entity)
+---
+tags:
+- identity
+- profile
+- computer
+- entity
+- technology
+---
 
-## **Introduction**
+# Computer Profile (Entity)
 
-The **Computer Profile** Entity inherits from the [Base Profile](../../identity/profile/base_profile.md) and
+## Introduction
+
+The **Computer Profile** Entity inherits from the [Base Profile](base_profile.md) and
 represents a computer participant or resource within Tournament Organizer. It adds computer-specific attributes and
 relationships, such as type, manufacturer, model, year, and user.
 
@@ -10,9 +19,9 @@ It inherits properties from the [Base Entity](../../foundation/base_entity.md).
 
 ---
 
-## **Additional Attributes**
+## Additional Attributes
 
-**Note:** This entity inherits all attributes from [Base Profile](../../identity/profile/base_profile.md).
+**Note:** This entity inherits all attributes from [Base Profile](base_profile.md).
 
 | Attribute              | Description                                      | Type       | Required | Notes / Example                                                                                                                                       |
 | ---------------------- | ------------------------------------------------ | ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/documents/docs/domains/identity/profile/digital.md
+++ b/documents/docs/domains/identity/profile/digital.md
@@ -1,8 +1,17 @@
-# **Digital Profile** (Data Model – Entity)
+---
+tags:
+- identity
+- profile
+- digital
+- entity
+- platform
+---
 
-## **Introduction**
+# Digital Profile (Entity)
 
-The **Digital Profile** Entity inherits from the [Base Profile](../../identity/profile/base_profile.md) and
+## Introduction
+
+The **Digital Profile** Entity inherits from the [Base Profile](base_profile.md) and
 represents a digital asset, identity, or resource within Tournament Organizer. It adds digital-specific attributes and
 relationships, such as platform, handle, and owner.
 

--- a/documents/docs/domains/identity/profile/machine.md
+++ b/documents/docs/domains/identity/profile/machine.md
@@ -1,8 +1,17 @@
-# **Machine Profile** (Data Model – Entity)
+---
+tags:
+- identity
+- profile
+- machine
+- entity
+- equipment
+---
 
-## **Introduction**
+# Machine Profile (Entity)
 
-The **Machine Profile** Entity inherits from the [Base Profile](../../identity/profile/base_profile.md) and
+## Introduction
+
+The **Machine Profile** Entity inherits from the [Base Profile](base_profile.md) and
 represents a machine participant or resource within Tournament Organizer. It adds machine-specific attributes and
 relationships, such as type, manufacturer, model, year, and operator.
 

--- a/documents/docs/domains/identity/profile/plant.md
+++ b/documents/docs/domains/identity/profile/plant.md
@@ -1,8 +1,17 @@
-# **Plant Profile** (Data Model – Entity)
+---
+tags:
+- identity
+- profile
+- plant
+- entity
+- nature
+---
 
-## **Introduction**
+# Plant Profile (Entity)
 
-The **Plant Profile** Entity inherits from the [Base Profile](../../identity/profile/base_profile.md) and
+## Introduction
+
+The **Plant Profile** Entity inherits from the [Base Profile](base_profile.md) and
 represents a plant participant or resource within Tournament Organizer. It adds plant-specific attributes and
 relationships, such as species, variety, date of planting, and caretaker.
 

--- a/documents/docs/domains/identity/profile/robot.md
+++ b/documents/docs/domains/identity/profile/robot.md
@@ -1,8 +1,17 @@
-# **Robot Profile** (Data Model – Entity)
+---
+tags:
+- identity
+- profile
+- robot
+- entity
+- automation
+---
 
-## **Introduction**
+# Robot Profile (Entity)
 
-The **Robot Profile** Entity inherits from the [Base Profile](../../identity/profile/base_profile.md) and
+## Introduction
+
+The **Robot Profile** Entity inherits from the [Base Profile](base_profile.md) and
 represents a robot participant or resource within Tournament Organizer. It adds robot-specific attributes and
 relationships, such as type, manufacturer, model, year, and operator.
 

--- a/documents/docs/domains/identity/profile/software.md
+++ b/documents/docs/domains/identity/profile/software.md
@@ -1,8 +1,17 @@
-# **Software Profile** (Data Model – Entity)
+---
+tags:
+- identity
+- profile
+- software
+- entity
+- application
+---
 
-## **Introduction**
+# Software Profile (Entity)
 
-The **Software Profile** Entity inherits from the [Base Profile](../../identity/profile/base_profile.md) and
+## Introduction
+
+The **Software Profile** Entity inherits from the [Base Profile](base_profile.md) and
 represents a software participant or resource within Tournament Organizer. It adds software-specific attributes and
 relationships, such as type, vendor, version, license, and administrator.
 

--- a/documents/docs/domains/identity/profile/vehicle.md
+++ b/documents/docs/domains/identity/profile/vehicle.md
@@ -1,8 +1,17 @@
-# **Vehicle Profile** (Data Model – Entity)
+---
+tags:
+- identity
+- profile
+- vehicle
+- entity
+- transportation
+---
 
-## **Introduction**
+# Vehicle Profile (Entity)
 
-The **Vehicle Profile** Entity inherits from the [Base Profile](../../identity/profile/base_profile.md) and
+## Introduction
+
+The **Vehicle Profile** Entity inherits from the [Base Profile](base_profile.md) and
 represents a vehicle participant or resource within Tournament Organizer. It adds vehicle-specific attributes and
 relationships, such as type, make, model, year, registration, and owner.
 

--- a/documents/docs/domains/identity/role/permission/operation.md
+++ b/documents/docs/domains/identity/role/permission/operation.md
@@ -1,14 +1,23 @@
-# **Operation** (Data Model - Template Entity)
+---
+tags:
+- identity
+- role
+- permission
+- operation
+- template-entity
+---
 
-## **Introduction**
+# Operation (Template Entity)
+
+## Introduction
 
 An **Operation** Entity Template defines a reusable blueprint for a specific action or activity that can be performed on
 resources within the tournament system. It provides a standardized way to define what operations are available and how
 they should be executed.
 
-As a Template Entity, it possesses a unique identity and lifecycle, managed according to the [Base Entity](../../../foundation/base_entity.md). When used, its
-definition is typically **copied** into the target context, allowing for potential minor modifications or annotations
-without altering the original template.
+As a Template Entity, it possesses a unique identity and lifecycle, managed according to the
+[Base Entity](../../../foundation/base_entity.md). When used, its definition is typically **copied** into the target
+context, allowing for potential minor modifications or annotations without altering the original template.
 
 It inherits properties from the [Base Entity](../../../foundation/base_entity.md).
 

--- a/documents/docs/domains/identity/role/permission/operation.md
+++ b/documents/docs/domains/identity/role/permission/operation.md
@@ -23,10 +23,10 @@ It inherits properties from the [Base Entity](../../../foundation/base_entity.md
 
 ---
 
-## **Attributes**
+## Attributes
 
 **Note:** This Entity Template includes the standard attributes (`ID`, `Status`, `CreatedAt`, `LastUpdatedAt`) defined
-in the .
+in the [Base Entity](../../../foundation/base_entity.md).
 
 | Attribute       | Description                                                      | Type         | Required | Notes / Example                                          |
 | --------------- | ---------------------------------------------------------------- | ------------ | -------- | -------------------------------------------------------- |
@@ -39,12 +39,10 @@ in the .
 
 ---
 
-## **Relationships**
+## Relationships
 
 - An `Operation` Entity Template is referenced by entities.
-- An `Operation` Entity Template may be applicable to multiple 🚨 **BROKEN:** 🚨 **BROKEN:** 🚨 **BROKEN:**
-
-  [Resource Type](../permission/resource_type.md) 🚨 🚨 🚨 entities.
+- An `Operation` Entity Template may be applicable to multiple [Resource Type](resource_type.md) entities.
 
 ### Parent Relationships
 
@@ -56,9 +54,7 @@ in the .
 
 ### Related Entities
 
-- 🚨 **BROKEN:** 🚨 **BROKEN:** 🚨 **BROKEN:** [Resource Type](../permission/resource_type.md)
-
-  🚨 🚨 🚨 - Resource types this operation can be applied to
+- [Resource Type](resource_type.md) - Resource types this operation can be applied to
 
 ---
 

--- a/documents/docs/domains/identity/role/permission/permission.md
+++ b/documents/docs/domains/identity/role/permission/permission.md
@@ -1,13 +1,22 @@
-# **Permission** (Data Model - Template Entity)
+---
+tags:
+- identity
+- role
+- permission
+- authorization
+- template-entity
+---
 
-## **Introduction**
+# Permission (Template Entity)
+
+## Introduction
 
 A **Permission** Entity Template defines a reusable blueprint for a specific authorization or access right within the
 tournament system. It provides a standardized way to define what actions or resources an entity can access or modify.
 
-As a Template Entity, it possesses a unique identity and lifecycle, managed according to the [Base Entity](../../../foundation/base_entity.md). When used, its
-definition is typically **copied** into the target context, allowing for potential minor modifications or annotations
-without altering the original template.
+As a Template Entity, it possesses a unique identity and lifecycle, managed according to the
+[Base Entity](../../../foundation/base_entity.md). When used, its definition is typically **copied** into the target
+context, allowing for potential minor modifications or annotations without altering the original template.
 
 It inherits properties from the [Base Entity](../../../foundation/base_entity.md).
 

--- a/documents/docs/domains/identity/role/permission/permission.md
+++ b/documents/docs/domains/identity/role/permission/permission.md
@@ -22,10 +22,10 @@ It inherits properties from the [Base Entity](../../../foundation/base_entity.md
 
 ---
 
-## **Attributes**
+## Attributes
 
 **Note:** This Entity Template includes the standard attributes (`ID`, `Status`, `CreatedAt`, `LastUpdatedAt`) defined
-in the .
+in the [Base Entity](../../../foundation/base_entity.md).
 
 | Attribute       | Description                                                                                                                                                                                   | Type   | Required | Notes / Example                                        |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | -------- | ------------------------------------------------------ |
@@ -39,7 +39,7 @@ in the .
 
 ---
 
-## **Relationships**
+## Relationships
 
 - A `Permission` Entity Template is referenced by [Role](../../../foundation/base_entity.md) entities.
 - A `Permission` Entity Template applies to one [Resource Type](resource_type.md) entity.

--- a/documents/docs/domains/identity/role/permission/resource_type.md
+++ b/documents/docs/domains/identity/role/permission/resource_type.md
@@ -1,14 +1,23 @@
-# **Resource Type** (Data Model - Template Entity)
+---
+tags:
+- identity
+- role
+- permission
+- resource-type
+- template-entity
+---
 
-## **Introduction**
+# Resource Type (Template Entity)
+
+## Introduction
 
 A **Resource Type** Entity Template defines a reusable blueprint for a specific category of resources or entities within
 the tournament system. It provides a standardized way to classify and organize different types of resources that can be
 managed, accessed, or operated upon.
 
-As a Template Entity, it possesses a unique identity and lifecycle, managed according to the [Base Entity](../../../foundation/base_entity.md). When used, its
-definition is typically **copied** into the target context, allowing for potential minor modifications or annotations
-without altering the original template.
+As a Template Entity, it possesses a unique identity and lifecycle, managed according to the
+[Base Entity](../../../foundation/base_entity.md). When used, its definition is typically **copied** into the target
+context, allowing for potential minor modifications or annotations without altering the original template.
 
 It inherits properties from the [Base Entity](../../../foundation/base_entity.md).
 

--- a/documents/docs/domains/identity/role/permission/resource_type.md
+++ b/documents/docs/domains/identity/role/permission/resource_type.md
@@ -23,10 +23,10 @@ It inherits properties from the [Base Entity](../../../foundation/base_entity.md
 
 ---
 
-## **Attributes**
+## Attributes
 
 **Note:** This Entity Template includes the standard attributes (`ID`, `Status`, `CreatedAt`, `LastUpdatedAt`) defined
-in the .
+in the [Base Entity](../../../foundation/base_entity.md).
 
 | Attribute       | Description                                                                                                                                                                                            | Type       | Required | Notes / Example                                              |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- | -------- | ------------------------------------------------------------ |
@@ -34,17 +34,15 @@ in the .
 | **Description** | Detailed description of the resource type template and its purpose.                                                                                                                                    | Text       | Yes      | `"Represents a competitive match between participants"`      |
 | **Type**        | The type of resource type template.                                                                                                                                                                    | String     | Yes      | `"Entity"`, `"Value Object"`, `"Service"`, `"Configuration"` |
 | **Category**    | The category this resource type belongs to.                                                                                                                                                            | String     | Yes      | `"Competition"`, `"Administration"`, `"System"`, `"Media"`   |
-| **Operations**  | List of 🚨 **BROKEN:** 🚨 **BROKEN:** 🚨 **BROKEN:** 🚨 **BROKEN:** [Operation](../permission/operation.md) 🚨 🚨 🚨 🚨 entities that can be performed on this resource type. | List[UUID] | Optional | References to operation entities                             |
+| **Operations**  | List of [Operation](operation.md) entities that can be performed on this resource type. | List[UUID] | Optional | References to operation entities                             |
 | **Notes**       | Additional notes about the resource type template.                                                                                                                                                     | Text       | Optional | `"Requires special handling for data integrity"`             |
 
 ---
 
-## **Relationships**
+## Relationships
 
 - A `Resource Type` Entity Template is referenced by entities.
-- A `Resource Type` Entity Template may have multiple 🚨 **BROKEN:** 🚨 **BROKEN:** 🚨 **BROKEN:** 🚨 **BROKEN:**
-
-  [Operation](../permission/operation.md) 🚨 🚨 🚨 🚨 entities associated.
+- A `Resource Type` Entity Template may have multiple [Operation](operation.md) entities associated.
 
 ### Parent Relationships
 
@@ -56,10 +54,7 @@ in the .
 
 ### Related Entities
 
-- 🚨 **BROKEN:** 🚨 **BROKEN:** 🚨 **BROKEN:** 🚨 **BROKEN:**
-
-  [Operation](../permission/operation.md) 🚨 🚨 🚨 🚨 - Operations that can be performed on
-  this resource type
+- [Operation](operation.md) - Operations that can be performed on this resource type
 
 ---
 

--- a/documents/docs/domains/identity/role/responsibility/expectation.md
+++ b/documents/docs/domains/identity/role/responsibility/expectation.md
@@ -1,6 +1,15 @@
-# **Expectation** (Data Model - Value Object)
+---
+tags:
+- identity
+- role
+- responsibility
+- expectation
+- value-object
+---
 
-## **Introduction**
+# Expectation (Value Object)
+
+## Introduction
 
 An **Expectation** is a Value Object that represents a standard of conduct, behavior, or outcome expected from a Role or
 Responsibility. Expectations are referenced to clarify what is required or valued in a given context.

--- a/documents/docs/domains/identity/role/responsibility/responsibility.md
+++ b/documents/docs/domains/identity/role/responsibility/responsibility.md
@@ -23,10 +23,10 @@ It inherits properties from the [Base Entity](../../../foundation/base_entity.md
 
 ---
 
-## **Attributes**
+## Attributes
 
 **Note:** This Entity Template includes the standard attributes (`ID`, `Status`, `CreatedAt`, `LastUpdatedAt`) defined
-in the .
+in the [Base Entity](../../../foundation/base_entity.md).
 
 | Attribute        | Description                                                                                                                                                                       | Type       | Required | Notes / Example                                                            |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------- | -------------------------------------------------------------------------- |
@@ -40,7 +40,7 @@ in the .
 
 ---
 
-## **Relationships**
+## Relationships
 
 - A `Responsibility` Entity Template is referenced by [Role](../role.md) entities.
 - A `Responsibility` Entity Template may contain multiple [Task](task.md) entities.

--- a/documents/docs/domains/identity/role/responsibility/responsibility.md
+++ b/documents/docs/domains/identity/role/responsibility/responsibility.md
@@ -1,14 +1,23 @@
-# **Responsibility** (Data Model - Template Entity)
+---
+tags:
+- identity
+- role
+- responsibility
+- duty
+- template-entity
+---
 
-## **Introduction**
+# Responsibility (Template Entity)
+
+## Introduction
 
 A **Responsibility** Entity Template defines a reusable blueprint for a specific duty, task, or obligation that can be
 assigned to roles within the tournament system. It provides a standardized way to define what individuals or entities
 are expected to do in their assigned roles.
 
-As a Template Entity, it possesses a unique identity and lifecycle, managed according to the [Base Entity](../../../foundation/base_entity.md). When used, its
-definition is typically **copied** into the target context, allowing for potential minor modifications or annotations
-without altering the original template.
+As a Template Entity, it possesses a unique identity and lifecycle, managed according to the
+[Base Entity](../../../foundation/base_entity.md). When used, its definition is typically **copied** into the target
+context, allowing for potential minor modifications or annotations without altering the original template.
 
 It inherits properties from the [Base Entity](../../../foundation/base_entity.md).
 

--- a/documents/docs/domains/identity/role/responsibility/skill.md
+++ b/documents/docs/domains/identity/role/responsibility/skill.md
@@ -1,6 +1,15 @@
-# **Skill** (Data Model - Value Object)
+---
+tags:
+- identity
+- role
+- responsibility
+- skill
+- value-object
+---
 
-## **Introduction**
+# Skill (Value Object)
+
+## Introduction
 
 A **Skill** is a Value Object that represents a specific ability, competency, or area of expertise required to fulfill a
 Responsibility or Role. Skills are referenced in Responsibilities to clarify requirements and support evaluation or

--- a/documents/docs/domains/identity/role/responsibility/task.md
+++ b/documents/docs/domains/identity/role/responsibility/task.md
@@ -1,6 +1,15 @@
-# **Task** (Data Model - Entity)
+---
+tags:
+- identity
+- role
+- responsibility
+- task
+- entity
+---
 
-## **Introduction**
+# Task (Entity)
+
+## Introduction
 
 A **Task** Entity represents a specific task or assignment that needs to be completed within the tournament system. It
 provides a consistent way to handle task information for work management, assignment tracking, and responsibility

--- a/documents/docs/domains/identity/role/responsibility/tracking.md
+++ b/documents/docs/domains/identity/role/responsibility/tracking.md
@@ -1,6 +1,15 @@
-# **Tracking** (Data Model - Value Object)
+---
+tags:
+- identity
+- role
+- responsibility
+- tracking
+- value-object
+---
 
-## **Introduction**
+# Tracking (Value Object)
+
+## Introduction
 
 A **Tracking** is a **Value Object** that represents the execution monitoring and progress tracking for a Task. This
 model captures the "how it's being done" aspects of task execution, including progress, time tracking, and

--- a/documents/docs/domains/identity/role/specialization.md
+++ b/documents/docs/domains/identity/role/specialization.md
@@ -1,14 +1,23 @@
-# **Specialization** (Data Model - Template Entity)
+---
+tags:
+- identity
+- role
+- specialization
+- template-entity
+- variation
+---
 
-## **Introduction**
+# Specialization (Template Entity)
+
+## Introduction
 
 A **Specialization** Entity Template defines a reusable blueprint for a specific variation or specialization of a role
 within the tournament system. It allows for creating more specific versions of base roles, such as "Senior Referee" or
 "Junior Coach".
 
-As a Template Entity, it possesses a unique identity and lifecycle, managed according to the [Base Entity](../../foundation/base_entity.md). When used, its
-definition is typically **copied** into the target context, allowing for potential minor modifications or annotations
-without altering the original template.
+As a Template Entity, it possesses a unique identity and lifecycle, managed according to the
+[Base Entity](../../foundation/base_entity.md). When used, its definition is typically **copied** into the target
+context, allowing for potential minor modifications or annotations without altering the original template.
 
 It inherits properties from the [Base Entity](../../foundation/base_entity.md).
 


### PR DESCRIPTION
## Summary
This PR completes the identity domain documentation rewrite by converting the remaining 19 files from the old format to the new YAML front matter standards, excluding the attributes folder which was completed in #28/#29.

## Changes Made
- ✅ Converted 19 files from \# **Title** (Data Model - Entity Type)\ to new format
- ✅ Added proper YAML front matter with domain-specific tags
- ✅ Fixed section headers (removed bold formatting)
- ✅ Updated entity type indicators: (Template Entity), (Entity), (Value Object)
- ✅ Fixed broken links and Base Entity references
- ✅ All files pass markdownlint validation

## Files Updated
### Account Subdomain (2 files)
- \ccount/setting/setting.md\
- \ccount/setting/scope.md\

### Profile Subdomain (9 files)  
- \profile/animal.md\, \profile/art.md\, \profile/computer.md\
- \profile/digital.md\, \profile/machine.md\, \profile/plant.md\ 
- \profile/robot.md\, \profile/software.md\, \profile/vehicle.md\

### Role Subdomain (8 files)
- \ole/specialization.md\
- \ole/permission/operation.md\, \ole/permission/permission.md\, \ole/permission/resource_type.md\
- \ole/responsibility/expectation.md\, \ole/responsibility/responsibility.md\
- \ole/responsibility/skill.md\, \ole/responsibility/task.md\, \ole/responsibility/tracking.md\

## Validation
- ✅ All converted files pass markdownlint checks
- ✅ Documentation follows \.github/instructions/documentation-style-link.instructions.md\
- ✅ Proper YAML front matter format used throughout

Closes #30