### PR TITLE
Team Domain Documentation Standards Compliance

### DIFF
--- a/documents/docs/domains/team/README.md
+++ b/documents/docs/domains/team/README.md
@@ -1,132 +1,92 @@
-# **Team Domain**
+---
+tags:
+- team
+- domain
+- competition
+- roster
+- tournament
+- player
+---
 
-## **Overview**
+# Team Domain
+
+## Overview
 
 The Team domain defines the structure, management, and lifecycle of teams as the fundamental units of competition in the
 Tournament Organizer system. It covers all aspects of team composition, roster management, player roles, and team
-participation in tournaments and matches.
+participation in tournaments and matches. This domain supports both individual and group competition formats, ensuring
+flexibility and consistency across all sports and activities.
 
-This domain supports both individual and group competition formats, ensuring flexibility and consistency across all
-sports and activities.
+## Purpose
 
-## **Domain Structure**
+The Team domain enables tournament organizers to:
 
-### **Core Models**
+- Manage competitive units of any size (individual or group)
+- Track team composition, player assignments, and roster changes
+- Handle organizational affiliations and sponsorship relationships
+- Support tournament seeding and placement management
+- Maintain staff assignments and role management
+- Ensure consistent competition rules across different sports
 
-- \*\*\*\*: Central entity representing a competition unit (single or multiple participants)
-- **[Roster](../team/roster.md)**: Official list of players (starters, substitutes, reserves) for a team
+## Structure
+
+### Core Models
+
+- **[Team](team.md)**: Central entity representing a competition unit (single or multiple participants)
+- **[Roster](roster.md)**: Official list of players (starters, substitutes, reserves) for a team
 - **[Player](roster/player/player.md)**: Instance of a registrant as a player in a specific context
 - **[Seed](seed.md)**: Team seeding for tournament placement
 
-### **Supporting Templates**
+### Supporting Templates
 
-- \*\*\*\*: Template for team structure rules (active players, substitutes, gender composition)
 - **[Position](roster/player/position.md)**: Template for field positions (e.g., Goalkeeper, Point Guard)
 
-## **Template Entity Analysis**
+### Status Lifecycles
 
-### **Current Template Entities**
+**Team Statuses:**
 
-- **Team Format**: Defines standard team structure rules, copied or referenced for tournaments/matches
-- **Position**: Standardizes field roles, referenced by players and rosters
+- Draft → Active → Locked/Suspended → Archived
 
-### **Potential Template Entities**
+**Roster Statuses:**
 
-- **Team Templates**: Standard team archetypes (e.g., "Default 5v5 Soccer Team")
-- **Staff Role Templates**: Standard roles for coaches, managers, etc.
-- **Roster Configuration Templates**: Standard roster setups for different sports
+- Active → Locked → Archived
 
-## **Status Lifecycle**
+**Player Statuses:**
 
-### **Team Statuses**
+- Active ↔ Benched/Injured/Suspended
 
-- **Draft**: Team is being created/configured
-- **Active**: Team is eligible and participating
-- **Locked**: Team roster is locked for competition
-- **Suspended**: Team is temporarily ineligible
-- **Archived**: Team is preserved for historical reference
+## Example
 
-### **Roster Statuses**
+```mermaid
+graph TD
+    TD[Team Domain] --> T[Team: Thunder Strikers<br/>Status: Active<br/>Players: 5]
+    TD --> R[Roster: Active Roster<br/>Type: Competitive<br/>Players: 5]
+    TD --> P[Player: John Smith<br/>Position: Captain<br/>Status: Active]
+    TD --> S[Seed: Tournament Seed #3<br/>Based on: Rankings]
+    
+    T --> R
+    R --> P
+    T --> S
+    
+    T --> ORG[Organization: Elite Sports Club<br/>Relationship: Sponsor]
+    P --> POS[Position: Point Guard<br/>Type: Template]
+    T --> D[Discipline: Basketball<br/>Category: Indoor Sports]
+```
 
-- **Active**: Roster is current and modifiable
-- **Locked**: Roster is fixed for a match or stage
-- **Archived**: Roster is preserved for history
-
-### **Player Statuses**
-
-- **Active**: Player is available for selection
-- **Benched**: Player is not starting but available
-- **Injured**: Player is unavailable due to injury
-- **Suspended**: Player is temporarily ineligible
-
-### **Lifecycle Transitions**
-
-- Team: Draft → Active → Locked/Suspended → Archived
-- Roster: Active → Locked → Archived
-- Player: Active ↔ Benched/Injured/Suspended
-
-## **Relationships & Cross-References**
-
-- **Team ↔ Organization**: Teams may be affiliated with or sponsored by organizations
-- **Team ↔ Player**: Teams manage a roster of players
-- **Team ↔ Activity Discipline**: Teams participate in specific disciplines
-- **Team ↔ Match**: Teams compete in matches
-- **Roster ↔ Player**: Rosters manage player roles and status
-- **Roster ↔ Team Format**: Rosters are validated against team format rules
-- **Player ↔ Registrant**: Players are instances of registrants in a competition context
-- **Player ↔ Position**: Players are assigned field positions
-- **Seed ↔ Team**: Seeds determine team placement in tournaments
-
-## **Quality Standards**
-
-- All models include comprehensive attribute documentation
-- Cross-references are accurate and up to date
-- Status lifecycles are clearly defined
-- Template entity usage is documented
-- Practical examples are provided where relevant
-- Consistent formatting and terminology throughout
-
-## **Implementation Guidelines**
-
-- Validate team and roster composition against discipline and tournament rules
-- Enforce status transitions and lifecycle rules
-- Use template entities for standardization and efficiency
-- Maintain accurate cross-references between all related models
-- Regularly review and update documentation for clarity and completeness
-
-## **Related Domains**
-
-- \*\*\*\*: Tournament structure and management
-- \*\*\*\*: Match and event scheduling
-- \*\*\*\*: Financial management
-- \*\*\*\*: Registrant and participant management
-
----
-
-**Last Updated**: June 24, 2025 **Version**: 1.0 **Status**: Active **Next Review**: July 24, 2025
-
-## References
-
-- [ISO 8000-2:2017 - Data quality - Part 2: Vocabulary](https://www.iso.org/standard/36326.html)
-- [ISO 20121:2012 - Event sustainability management systems](https://www.iso.org/standard/54552.html)
-- [Domain-Driven Design: Tackling Complexity in the Heart of Software](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215)
-
-  by Eric Evans - Entity and Template patterns
-
-- [Event Management Body of Knowledge (EMBOK)](https://www.embok.org/index.php/embok-model) - Event team management
-
-  standards
+This example illustrates the Team domain's core structure with the Thunder Strikers basketball team. The team entity
+maintains an active competitive roster with assigned players, organizational sponsorship, and tournament seeding.
+Players have specific positions and statuses, while the roster manages overall team composition. This structure
+enables tournament organizers to track team eligibility, manage competition participation, handle roster changes,
+and maintain accurate records throughout the tournament lifecycle.
 
 ## See Also
 
-- [Team](../team/team.md)
-- [Roster](../team/roster.md)
-- [Seed](../team/seed.md)
-- [Roster README](../team/roster/README.md)
-- [Tournament README](../tournament/README.md)
-- [Schedule README](../schedule/README.md)
-- [Discipline README](../discipline/README.md)
-- [Registration README](../registration/README.md)
-- [Organization README](../organization/README.md)
-- [Standing README](../standing/README.md)
-- [Business README](../README.md)
+- [Team](team.md) - Core team entity documentation
+- [Roster](roster.md) - Team roster management
+- [Player](roster/player/player.md) - Player entity details
+- [Seed](seed.md) - Tournament seeding values
+- [Position](roster/player/position.md) - Player position templates
+- [Tournament](../tournament/README.md) - Tournament structure and management
+- [Schedule](../schedule/README.md) - Match and event scheduling
+- [Registration](../registration/README.md) - Registrant and participant management
+- [Organization](../organization/README.md) - Team affiliations and sponsorships

--- a/documents/docs/domains/team/roster.md
+++ b/documents/docs/domains/team/roster.md
@@ -1,24 +1,23 @@
+---
+tags:
+- roster
+- team
+- redirect
+---
+
 # Team Roster
 
-<!-- TODO: Add team roster documentation -->
+This page serves as a redirect to the main roster documentation in the roster subdirectory.
 
-## References
-
-- [ISO 8000-2:2017 - Data quality - Part 2: Vocabulary](https://www.iso.org/standard/36326.html)
-- [ISO 20121:2012 - Event sustainability management systems](https://www.iso.org/standard/54552.html)
-- [Domain-Driven Design: Tackling Complexity in the Heart of Software](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215)
-
-  by Eric Evans - Entity patterns
-
-- [Event Management Body of Knowledge (EMBOK)](https://www.embok.org/index.php/embok-model) - Event roster management
-
-  standards
+For detailed roster template documentation, see [Roster Template Entity](roster/roster.md).
 
 ## See Also
 
-- [Team README](../team/README.md)
-- [Team](../team/team.md)
-- [Roster README](../team/roster/README.md)
+- [Roster Template Entity](roster/roster.md) - Main roster template documentation
+- [Player](roster/player/player.md) - Player entity documentation
+- [Position](roster/player/position.md) - Player position templates
+- [Team](team.md) - Core team entity
+- [Team Domain README](README.md) - Team domain overview
 - [Identity README](../identity/README.md)
 - [Registration README](../registration/README.md)
 - [Business README](../README.md)

--- a/documents/docs/domains/team/roster/player/player.md
+++ b/documents/docs/domains/team/roster/player/player.md
@@ -2,7 +2,8 @@
 
 ## **Introduction**
 
-A **Player** Entity represents a specific instance of a participating in a defined context, such as competing in an .
+A **Player** Entity represents a specific instance of a [Registrant](../../../../registration/registrant.md)
+participating in a defined context, such as competing in a [Tournament](../../../../tournament/tournament.md).
 
 It captures context-specific attributes (e.g., jersey number, role, position) and links back to the core `Registrant`
 entity, which contains the fundamental identity and profile information.
@@ -31,15 +32,15 @@ It inherits properties from the [Base Entity](../../../foundation/base_entity.md
 
 ## **Relationships**
 
-- A `Player` Entity is linked to one entity.
+- A `Player` Entity is linked to one [Registrant](../../../../registration/registrant.md) entity.
 - A `Player` Entity may be assigned to one [Position](position.md) within a team context.
-- A `Player` Entity may participate in multiple entities.
-- A `Player` Entity belongs to one entity.
+- A `Player` Entity may participate in multiple [Match](../../../../schedule/match.md) entities.
+- A `Player` Entity belongs to one [Team](../../team.md) entity.
 
 ### Parent Relationships
 
-- - The core identity and profile information
-- - The team this player belongs to
+- [Registrant](../../../../registration/registrant.md) - The core identity and profile information
+- [Team](../../team.md) - The team this player belongs to
 
 ### Child Relationships
 
@@ -48,8 +49,8 @@ It inherits properties from the [Base Entity](../../../foundation/base_entity.md
 ### Related Entities
 
 - [Position](position.md) - The player's assigned position
-- - Matches the player participates in
-- - The context of participation
+- [Match](../../../../schedule/match.md) - Matches the player participates in
+- [Tournament](../../../../tournament/tournament.md) - The context of participation
 
 ---
 

--- a/documents/docs/domains/team/roster/player/position.md
+++ b/documents/docs/domains/team/roster/player/position.md
@@ -5,10 +5,11 @@
 A **Position** Entity Template defines a reusable blueprint for a specific role or location occupied by a participant
 within the context of a team-based activity (e.g., Goalkeeper, Point Guard, Setter).
 
-As a Template Entity, it possesses a unique identity and lifecycle, managed according to the [Base Entity](../../../foundation/base_entity.md). It serves as a standard
+As a Template Entity, it possesses a unique identity and lifecycle, managed according to the
+[Base Entity](../../../foundation/base_entity.md). It serves as a standard
 definition that can be referenced when configuring team formats, assigning roles, or describing player capabilities. The
 specific sport or activity context is determined by how this template is used (e.g., referenced within a `Team Format`
-linked to an ).
+linked to an [Activity Discipline](../../../../discipline/discipline.md)).
 
 Using Field Position templates helps to:
 

--- a/documents/docs/domains/team/roster/roster.md
+++ b/documents/docs/domains/team/roster/roster.md
@@ -1,125 +1,67 @@
-# **Roster** (Data Model - Template Entity)
+---
+tags:
+- roster
+- template-entity
+- team
+- player
+- competition
+---
 
-## **Introduction**
+# Roster (Template Entity)
 
-A **Roster** Template Entity defines a reusable blueprint for roster structures and configurations that can be used to
+## Overview
+
+A Roster Template Entity defines a reusable blueprint for roster structures and configurations that can be used to
 create specific roster instances. It provides a standardized framework for roster types, player roles, and team
 composition patterns that can be applied across different contexts and tournaments.
 
-As a Template Entity, it possesses a unique identity and lifecycle, managed according to the [Base Entity](../../foundation/base_entity.md), with additional template-specific attributes for versioning and reuse.
+## Purpose
 
----
+The Roster Template Entity enables tournament organizers to:
 
-## **Attributes**
+- Standardize team composition rules across competitions
+- Define player role categories and limitations
+- Establish consistent roster requirements for different sports
+- Create reusable roster configurations for tournaments
+- Ensure compliance with discipline-specific rules
+- Streamline team registration and validation processes
 
-**Note:** This Template Entity includes the standard attributes (`ID`, `Status`, `CreatedAt`, `LastUpdatedAt`) defined in the [Base Entity](../../foundation/base_entity.md).
+## Structure
+
+This Template Entity includes the standard attributes defined in the [Base Entity](../../foundation/base_entity.md).
 
 | Attribute       | Description                                                                 | Type   | Required | Notes / Example                                |
 | --------------- | --------------------------------------------------------------------------- | ------ | -------- | ---------------------------------------------- |
-| **Name**        | The name of the roster template.                                            | String | Yes      | `"Standard Roster"`, `"Tournament Roster"`     |
-| **Type**        | The type of roster template.                                                | String | Yes      | `"Competitive"`, `"Recreational"`, `"Tournament"` |
-| **Description** | Description of the roster template and its characteristics.                 | Text   | Optional | `"Standard competitive roster structure"`      |
-| **Max Starters** | Maximum number of starters for this roster template.                       | Integer| Yes      | `5`, `11`, `15`                                |
-| **Max Substitutes** | Maximum number of substitutes for this roster template.                   | Integer| Yes      | `3`, `5`, `7`                                  |
-| **Max Reserves** | Maximum number of reserves for this roster template.                       | Integer| Optional | `2`, `3`, `5`                                  |
-| **Player Roles** | Standard player roles for this roster template.                            | List[String] | Yes | `["Starter", "Substitute", "Reserve"]`         |
-| **Requirements** | Standard requirements for this roster template.                            | List[String] | Optional | `["Minimum 8 players", "Maximum 15 players"]`  |
+| **Name**        | The name of the roster template                                            | String | Yes      | `"Standard Roster"`, `"Tournament Roster"`     |
+| **Type**        | The type of roster template                                                | String | Yes      | `"Competitive"`, `"Recreational"`, `"Tournament"` |
+| **Description** | Description of the roster template and its characteristics                 | Text   | Optional | `"Standard competitive roster structure"`      |
+| **Max Starters** | Maximum number of starters for this roster template                       | Integer| Yes      | `5`, `11`, `15`                                |
+| **Max Substitutes** | Maximum number of substitutes for this roster template                   | Integer| Yes      | `3`, `5`, `7`                                  |
+| **Max Reserves** | Maximum number of reserves for this roster template                       | Integer| Optional | `2`, `3`, `5`                                  |
+| **Player Roles** | Standard player roles for this roster template                            | List[String] | Yes | `["Starter", "Substitute", "Reserve"]`         |
+| **Requirements** | Standard requirements for this roster template                            | List[String] | Optional | `["Minimum 8 players", "Maximum 15 players"]`  |
 
----
+## Example
 
-## **Relationships**
+```mermaid
+graph TD
+    RT[Roster Template: Basketball Competitive<br/>Type: Competitive] --> MS[Max Starters: 5<br/>Role: Active Players]
+    RT --> MSub[Max Substitutes: 7<br/>Role: Bench Players]
+    RT --> MR[Max Reserves: 3<br/>Role: Additional Squad]
+    RT --> PR[Player Roles<br/>Starter, Substitute, Reserve<br/>Captain, Vice Captain]
+    RT --> REQ[Requirements<br/>Minimum 8 players<br/>Maximum 15 players]
+```
 
-- A `Roster` Template Entity may be referenced by roster instance entities.
-- A `Roster` Template Entity may be associated with team template entities.
-- A `Roster` Template Entity may be associated with player template entities.
-- A `Roster` Template Entity may be referenced by tournament template entities.
-
-### Parent Relationships
-
-- Team templates - The team template this roster template belongs to
-- Tournament templates - The tournament template this roster template is used in
-
-### Child Relationships
-
-- Roster instances - Specific rosters created from this template
-- Player instances - Player assignments using this roster template
-
-### Related Entities
-
-- Player templates - Player types that can be part of this roster template
-- Match templates - Match types this roster template can be used in
-
----
-
-## **Considerations**
-
-- **Template Nature:** This template defines a standard roster type. Instance-specific variations or customizations
-
-  belong on the copied instance within its specific context (e.g., a specific team's implementation).
-
-- **Copy Mechanism:** The process of copying this template definition into a target context (like a specific team)
-
-  needs to be handled by application logic.
-
-- **Template Management:**
-
-  - Templates should be curated and maintained by team administrators
-  - New templates can be added based on roster standards and organizational requirements
-  - Templates should be reviewed periodically for effectiveness and fairness
-
-- **Role Management:**
-
-  - **STARTER:** Primary players who begin the match
-  - **SUBSTITUTE:** Players who can replace starters during a match
-  - **RESERVE:** Players who can replace starters/substitutes before a match begins
-
-- **Role Transitions:**
-
-  - Substitutes can be activated during a match
-  - Reserves can only be activated before a match begins
-  - Role changes must follow tournament rules
-
-- **Status Tracking:**
-
-  - Each player's status affects their availability
-  - Status changes must be tracked and validated
-  - Roster status affects its modifiability
-
-- **Validation Rules:**
-
-  - Must respect maximum numbers for each role type
-  - Must follow tournament substitution rules
-  - Must maintain proper team composition
-
-- **Customization Balance:**
-
-  - Templates provide structure while allowing personalization
-  - Customizations should not break the fundamental roster structure
-  - System should support both template-based and fully custom rosters
-
----
-
-## References
-
-- [ISO 8000-2:2017 - Data quality - Part 2: Vocabulary](https://www.iso.org/standard/36326.html)
-- [ISO 20121:2012 - Event sustainability management systems](https://www.iso.org/standard/54552.html)
-- [Domain-Driven Design: Tackling Complexity in the Heart of Software](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215)
-
-  by Eric Evans - Entity Template patterns
-
-- [Event Management Body of Knowledge (EMBOK)](https://www.embok.org/index.php/embok-model) - Event roster management
-
-  standards
+This example shows a Basketball Competitive roster template that defines the structure for basketball teams. The
+template specifies 5 starting players, 7 substitutes, and 3 reserves for a maximum squad of 15 players. Player
+roles include standard categories (Starter, Substitute, Reserve) plus leadership roles (Captain, Vice Captain).
+Requirements ensure minimum viable team size and maximum roster limits. Tournament organizers use this template
+to validate team registrations, ensuring all basketball teams meet consistent composition standards while providing
+flexibility for different tournament formats and competition levels.
 
 ## See Also
 
-- [Roster README](../../team/roster/README.md)
-- [Team README](../../team/README.md)
-- [Team](../../team/team.md)
-- [Roster](../../team/roster.md)
-- [Identity README](../../identity/README.md)
-- [Discipline README](../../discipline/README.md)
-- [Schedule README](../../schedule/README.md)
-- [Business README](../../README.md)
-
----
+- [Team](../team.md) - Core team entity that uses roster templates
+- [Player](player/player.md) - Individual player entities within rosters
+- [Position](player/position.md) - Player position templates for field assignments
+- [Base Entity](../../foundation/base_entity.md) - Standard template entity attributes

--- a/documents/docs/domains/team/roster/roster.md
+++ b/documents/docs/domains/team/roster/roster.md
@@ -12,8 +12,8 @@ tags:
 ## Overview
 
 A Roster Template Entity defines a reusable blueprint for roster structures and configurations that can be used to
-create specific roster instances. It provides a standardized framework for roster types, player roles, and team
-composition patterns that can be applied across different contexts and tournaments.
+create specific roster instances. It provides a standardized framework for organizing player lists (such as main
+players, substitutes, and reserves) that can be applied across different contexts and tournaments.
 
 ## Purpose
 
@@ -32,9 +32,9 @@ This Template Entity includes the standard attributes defined in the [Base Entit
 
 | Attribute       | Description                                                                 | Type          | Required | Notes / Example                                |
 | --------------- | --------------------------------------------------------------------------- | ------------- | -------- | ---------------------------------------------- |
-| **Players**     | List of main players in the roster                                        | List[Player]  | Yes      | Starting lineup and active players             |
-| **Substitutes** | List of substitute players available for rotation                          | List[Player]  | Yes      | Bench players ready to enter the game         |
-| **Reserves**    | List of reserve players for additional squad depth                        | List[Player]  | Optional | Extra players for emergency situations         |
+| **Players**     | List of main players in the roster                                        | List[UUID]    | Yes      | Starting lineup and active players             |
+| **Substitutes** | List of substitute players available for rotation                          | List[UUID]    | Yes      | Bench players ready to enter the game         |
+| **Reserves**    | List of reserve players for additional squad depth                        | List[UUID]    | Optional | Extra players for emergency situations         |
 
 ## Example
 

--- a/documents/docs/domains/team/roster/roster.md
+++ b/documents/docs/domains/team/roster/roster.md
@@ -30,34 +30,40 @@ The Roster Template Entity enables tournament organizers to:
 
 This Template Entity includes the standard attributes defined in the [Base Entity](../../foundation/base_entity.md).
 
-| Attribute       | Description                                                                 | Type   | Required | Notes / Example                                |
-| --------------- | --------------------------------------------------------------------------- | ------ | -------- | ---------------------------------------------- |
-| **Name**        | The name of the roster template                                            | String | Yes      | `"Standard Roster"`, `"Tournament Roster"`     |
-| **Type**        | The type of roster template                                                | String | Yes      | `"Competitive"`, `"Recreational"`, `"Tournament"` |
-| **Description** | Description of the roster template and its characteristics                 | Text   | Optional | `"Standard competitive roster structure"`      |
-| **Max Starters** | Maximum number of starters for this roster template                       | Integer| Yes      | `5`, `11`, `15`                                |
-| **Max Substitutes** | Maximum number of substitutes for this roster template                   | Integer| Yes      | `3`, `5`, `7`                                  |
-| **Max Reserves** | Maximum number of reserves for this roster template                       | Integer| Optional | `2`, `3`, `5`                                  |
-| **Player Roles** | Standard player roles for this roster template                            | List[String] | Yes | `["Starter", "Substitute", "Reserve"]`         |
-| **Requirements** | Standard requirements for this roster template                            | List[String] | Optional | `["Minimum 8 players", "Maximum 15 players"]`  |
+| Attribute       | Description                                                                 | Type          | Required | Notes / Example                                |
+| --------------- | --------------------------------------------------------------------------- | ------------- | -------- | ---------------------------------------------- |
+| **Players**     | List of main players in the roster                                        | List[Player]  | Yes      | Starting lineup and active players             |
+| **Substitutes** | List of substitute players available for rotation                          | List[Player]  | Yes      | Bench players ready to enter the game         |
+| **Reserves**    | List of reserve players for additional squad depth                        | List[Player]  | Optional | Extra players for emergency situations         |
 
 ## Example
 
 ```mermaid
 graph TD
-    RT[Roster Template: Basketball Competitive<br/>Type: Competitive] --> MS[Max Starters: 5<br/>Role: Active Players]
-    RT --> MSub[Max Substitutes: 7<br/>Role: Bench Players]
-    RT --> MR[Max Reserves: 3<br/>Role: Additional Squad]
-    RT --> PR[Player Roles<br/>Starter, Substitute, Reserve<br/>Captain, Vice Captain]
-    RT --> REQ[Requirements<br/>Minimum 8 players<br/>Maximum 15 players]
+    R[Roster: Basketball Team<br/>Instance of Roster Template] --> P[Players<br/>List[Player]]
+    R --> S[Substitutes<br/>List[Player]]
+    R --> Res[Reserves<br/>List[Player]]
+    
+    P --> P1[Player 1: Point Guard]
+    P --> P2[Player 2: Shooting Guard]
+    P --> P3[Player 3: Small Forward]
+    P --> P4[Player 4: Power Forward]
+    P --> P5[Player 5: Center]
+    
+    S --> S1[Sub 1: Guard]
+    S --> S2[Sub 2: Forward]
+    S --> S3[Sub 3: Center]
+    
+    Res --> R1[Reserve 1: Utility]
+    Res --> R2[Reserve 2: Specialty]
 ```
 
-This example shows a Basketball Competitive roster template that defines the structure for basketball teams. The
-template specifies 5 starting players, 7 substitutes, and 3 reserves for a maximum squad of 15 players. Player
-roles include standard categories (Starter, Substitute, Reserve) plus leadership roles (Captain, Vice Captain).
-Requirements ensure minimum viable team size and maximum roster limits. Tournament organizers use this template
-to validate team registrations, ensuring all basketball teams meet consistent composition standards while providing
-flexibility for different tournament formats and competition levels.
+This example shows a Basketball roster with three distinct player categories. The Players list contains the
+starting five (Point Guard, Shooting Guard, Small Forward, Power Forward, Center). The Substitutes list
+includes bench players ready for rotation during the game. The Reserves list contains additional squad
+members for emergency situations or special circumstances. Each list contains Player entities that can be
+referenced and managed independently, providing clear organization of team composition and player availability
+for different game situations and tournament requirements.
 
 ## See Also
 

--- a/documents/docs/domains/team/seed.md
+++ b/documents/docs/domains/team/seed.md
@@ -1,67 +1,57 @@
-# **Seed** (Data Model - Entity)
-
-## **Introduction**
-
-A **Seed** Entity represents a ranked position assigned to a participant (individual or team) within a specific \***\*.
-This assignment is typically based on performance, rankings, or other criteria defined by a \*\***, aiming to create
-balanced and fair tournament structures like brackets or groups.
-
-As an Entity, it has its own identity and lifecycle, inheriting from the .
-
-It inherits properties from the [Base Entity](../foundation/base_entity.md).
-
+---
+tags:
+- seed
+- value-object
+- tournament
+- ranking
+- seeding
 ---
 
-## **Attributes**
+# Seed (Value Object)
 
-**Note:** This Entity includes the standard attributes (`ID`, `Status` [e.g., Active, Inactive], `CreatedAt`,
-`LastUpdatedAt`) defined in the [Base Entity](../foundation/base_entity.md).
+## Overview
+
+A Seed Value Object represents a ranked position assigned to a team within a specific tournament context.
+This assignment is typically based on performance, rankings, or other criteria defined by tournament organizers,
+aiming to create balanced and fair tournament structures like brackets or groups.
+
+## Purpose
+
+The Seed Value Object enables tournament organizers to:
+
+- Assign ranked positions to teams for tournament placement
+- Create balanced competition brackets and groups
+- Maintain fairness through systematic seeding processes
+- Track seeding criteria and rationale
+- Support various seeding methodologies
+- Enable proper tournament draw procedures
+
+## Structure
 
 | Attribute       | Description                                                                    | Type    | Required | Notes / Example                                    |
 | --------------- | ------------------------------------------------------------------------------ | ------- | -------- | -------------------------------------------------- |
-| **Ranking**     | The numerical rank associated with this seed (e.g., 1st, 2nd, 3rd).            | Integer | Yes      | `1`, `8`                                           |
-| **Name**        | Optional display name for the seed, often combining discipline/group and rank. | String  | Optional | `"Group A Seed 1"`, `"Main Bracket Seed #4"`       |
-| **Description** | Optional text providing additional context about the seed assignment.          | String  | Optional | `"Top seed based on international ranking points"` |
+| **Ranking**     | The numerical rank associated with this seed (e.g., 1st, 2nd, 3rd)            | Integer | Yes      | `1`, `8`                                           |
+| **Name**        | Optional display name for the seed, often combining discipline/group and rank | String  | Optional | `"Group A Seed 1"`, `"Main Bracket Seed #4"`       |
+| **Description** | Optional text providing additional context about the seed assignment          | String  | Optional | `"Top seed based on international ranking points"` |
 
----
+## Example
 
-## **Relationships**
+```mermaid
+graph TD
+    S[Seed: Tournament Seed #3<br/>Ranking: 3] --> T[Team: Thunder Strikers<br/>Standing: 3rd]
+    S --> C[Criteria: Previous Season Results<br/>Weight: 70%]
+    S --> P[Placement: Upper Bracket<br/>Round: 1]
+```
 
-- Seeds are used to populate structures like \***\* or \*\*** within a tournament.
-
----
-
-## **Considerations**
-
-- **Uniqueness:** The `Ranking` number should be unique within its context (e.g., within a group or bracket).
-- **Lifecycle:** Seeds should be managed throughout the tournament lifecycle, with status updates reflecting their
-
-  current state.
-
-- **Validation:** The `Ranking` should be a positive integer and should not exceed the total number of participants in
-
-  the context.
-
----
-
-## References
-
-- [ISO 8000-2:2017 - Data quality - Part 2: Vocabulary](https://www.iso.org/standard/36326.html)
-- [ISO 20121:2012 - Event sustainability management systems](https://www.iso.org/standard/54552.html)
-- [Domain-Driven Design: Tackling Complexity in the Heart of Software](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215)
-
-  by Eric Evans - Entity patterns
-
-- [Event Management Body of Knowledge (EMBOK)](https://www.embok.org/index.php/embok-model) - Event seeding standards
+This example shows Tournament Seed #3 assigned to the Thunder Strikers basketball team. The seed ranking of 3
+is based on their previous semi-final performance and current 3rd place league standing. The seeding criteria
+uses 70% weighting from previous season results, placing them in the upper bracket with a favorable tournament
+path. This systematic approach ensures fair competition distribution while providing transparency in seeding
+decisions for teams, organizers, and spectators.
 
 ## See Also
 
-- [Team README](../team/README.md)
-- [Team](../team/team.md)
-- [Tournament README](../tournament/README.md)
-- [Discipline README](../discipline/README.md)
-- [Ranking README](../ranking/README.md)
-- [Standing README](../standing/README.md)
-- [Business README](../README.md)
-
----
+- [Team](team.md) - Teams that receive seed assignments
+- [Tournament](../tournament/tournament.md) - Tournament structure using seeds
+- [Standing](../standing/standing.md) - Performance data used for seeding
+- [Ranking](../ranking/ranking.md) - Ranking systems that inform seeding

--- a/documents/docs/domains/team/team.md
+++ b/documents/docs/domains/team/team.md
@@ -1,62 +1,73 @@
-# **Team** (Data Model - Entity)
+---
+tags:
+- team
+- entity
+- competition
+- roster
+- tournament
+---
 
-## **Introduction**
+# Team (Entity)
 
-A **Team** Entity represents the fundamental unit of competition in tournaments, regardless of its size. Whether
-consisting of a single player or multiple participants, all competitive entities are treated as teams within the system.
+## Overview
+
+A Team Entity represents the fundamental unit of competition in tournaments, regardless of size. Whether consisting
+of a single player or multiple participants, all competitive entities are treated as teams within the system.
 This unified approach simplifies tournament management, match scheduling, and result tracking while maintaining
 consistency across different competition formats.
 
-It inherits properties from the [Base Entity](../foundation/base_entity.md).
+## Purpose
 
----
+The Team Entity serves as the primary competitive unit that:
 
-## **Attributes**
+- Represents all forms of competitive participation (individual or group)
+- Maintains roster composition and player assignments
+- Tracks organizational affiliations and sponsorships
+- Enables seeding and tournament placement
+- Supports media and documentation management
+- Provides a consistent interface for match scheduling and standings
 
-**Note:** This Entity includes the standard attributes (`ID`, `Status`, `CreatedAt`, `LastUpdatedAt`) defined in the [Base Entity](../foundation/base_entity.md).
+## Structure
+
+This Entity includes the standard attributes defined in the [Base Entity](../foundation/base_entity.md).
 
 | Attribute        | Description                                                                         | Type       | Required | Notes / Example                                                                          |
 | ---------------- | ----------------------------------------------------------------------------------- | ---------- | -------- | ---------------------------------------------------------------------------------------- |
-| **Name**         | Official title or designation of the team.                                          | String     | Yes      | `"Alpha Eagles"`, `"Thunder Strikers"`                                                   |
-| **Organization** | Reference to the this team belongs to or is sponsored by.                           | UUID       | No       | `org-uuid-123` (Company) or `org-uuid-456` (Sponsor)                                     |
-| **Roster**       | [List of players](../team/roster.md)                                  | List[UUID] | Yes      | References to Player entities. `[player-uuid-abc, player-uuid-def]`                      |
-| **Disciplines**  |                                                                                     | List[UUID] | Yes      | References to Activity Discipline entities. `[discipline-uuid-123, discipline-uuid-456]` |
-| **Staff**        | Coaches, managers, and supporting personnel.                                        | List[UUID] | No       | References to User entities with staff roles. `[user-uuid-789, user-uuid-012]`           |
-| **Seed**         | [Team's initial placement](seed.md)     | UUID       | No       | Reference to Seed entity. `seed-uuid-abc`                                                |
-| **Media**        | Optional list of references (by ID) to \*\*\*\* entities associated with this team. | List[UUID] | Optional | Example: `[media-a1b2c3d4-e5f6-4890-1234-567890abc099]`                                  |
+| **Name**         | Official title or designation of the team                                          | String     | Yes      | `"Alpha Eagles"`, `"Thunder Strikers"`                                                   |
+| **Organization** | Reference to the [Organization](../organization/organization.md) this team belongs to or is sponsored by | UUID | No | `org-uuid-123` (Company) or `org-uuid-456` (Sponsor) |
+| **Roster**       | List of [Players](roster/player/player.md) that make up the team                   | List[UUID] | Yes      | References to Player entities. `[player-uuid-abc, player-uuid-def]`                      |
+| **Disciplines**  | [Activity disciplines](../discipline/discipline.md) this team participates in      | List[UUID] | Yes      | References to Activity Discipline entities. `[discipline-uuid-123, discipline-uuid-456]` |
+| **Staff**        | Coaches, managers, and supporting personnel                                         | List[UUID] | No       | References to User entities with staff roles. `[user-uuid-789, user-uuid-012]`           |
+| **Seed**         | [Team's initial placement](seed.md) for tournament seeding                         | UUID       | No       | Reference to Seed entity. `seed-uuid-abc`                                                |
+| **Media**        | Optional list of [Media](../media/media.md) entities associated with this team     | List[UUID] | Optional | Example: `[media-a1b2c3d4-e5f6-4890-1234-567890abc099]`                                  |
 
----
+## Example
 
-## **Relationships**
+```mermaid
+graph TD
+    T[Team: Thunder Strikers<br/>Status: Active] --> O[Organization: Elite Sports Club<br/>Type: Sponsor]
+    T --> R1[Player: John Smith<br/>Position: Captain<br/>Jersey: 10]
+    T --> R2[Player: Sarah Wilson<br/>Position: Vice Captain<br/>Jersey: 7]
+    T --> R3[Player: Mike Chen<br/>Position: Starter<br/>Jersey: 23]
+    T --> D[Discipline: Basketball<br/>Category: Indoor Sports]
+    T --> S1[Staff: Coach Martinez<br/>Role: Head Coach]
+    T --> S2[Staff: Dr. Johnson<br/>Role: Team Physician]
+    T --> SD[Seed: Tournament Seed #3<br/>Based on: Previous Rankings]
+    T --> M[Media: Team Logo<br/>Type: Image<br/>Usage: Official]
+```
 
-- A `Team` Entity optionally references an \*\*\*\* (via `Organization`) for company affiliation or sponsorship.
-- It references multiple \*\*\*\* entities via the `Roster` attribute.
-- It references multiple \*\*\*\* entities via the `Disciplines` attribute.
-- It optionally references multiple \*\*\*\* entities via the `Staff` attribute.
-- It optionally references a [Seed](seed.md) entity
+This example shows the Thunder Strikers basketball team with all key attributes represented. The team has a
+sponsorship relationship with Elite Sports Club, maintains a roster of three active players with assigned
+positions and jersey numbers, participates in basketball discipline, employs coaching and medical staff,
+holds a #3 seed position for tournament placement, and has official media assets. This comprehensive
+structure enables tournament organizers to manage team composition, track performance, coordinate schedules,
+and maintain official records throughout the competition lifecycle.
 
-  via the `Seed` attribute.
+## See Also
 
-- It may be referenced by \*\*\*\* entities as a participant.
-- It may be referenced by \*\*\*\* entities for performance tracking.
-
----
-
-## **Considerations**
-
-- **Organization Types:** The `Organization` reference can represent either a company affiliation or a sponsorship
-
-  relationship.
-
-- **Roster Management:** The `Roster` list must be validated against the team's active disciplines and format
-
-  requirements.
-
-- **Staff Roles:** Staff members must have appropriate roles and permissions assigned.
-- **Lifecycle:** The team's status affects its participation eligibility and visibility.
-- **Seed Management:** The `Seed` is typically assigned during tournament registration or qualification.
-- **Single Player Teams:** Even teams with only one player in their roster are treated as full teams for all tournament
-
-  operations.
-
----
+- [Roster](roster.md) - Team roster management and player assignments
+- [Player](roster/player/player.md) - Individual player entities within teams
+- [Seed](seed.md) - Tournament seeding and placement values
+- [Organization](../organization/organization.md) - Team affiliations and sponsorships
+- [Tournament](../tournament/tournament.md) - Tournament structure and team participation
+- [Standing](../standing/standing.md) - Team performance tracking and rankings


### PR DESCRIPTION
This pull request addresses issue #65 by rewriting all Team domain documentation to follow the project's documentation standards and correcting the roster model structure.

## Changes Made

### Core Files Rewritten
- **team.md**: Rewrote as Entity with proper YAML front matter, entity type indicator, and comprehensive basketball team example with mermaid diagram
- **README.md**: Restructured to follow domain documentation standards with Overview→Purpose→Structure→Example→See Also format
- **roster/roster.md**: Rewrote as Template Entity with simplified structure containing only player list attributes
- **roster.md**: Created proper redirect file with YAML front matter
- **seed.md**: Rewrote as Value Object with tournament seeding example and placement logic

### Roster Model Corrections
- Simplified roster structure to contain only three attributes:
  - **players**: List[Player] - main players in the roster
  - **substitutes**: List[Player] - substitute players for rotation
  - **reserves**: List[Player] - reserve players for additional depth
- Removed template-specific attributes (max counts, roles, requirements)
- Updated example to show actual player lists instead of template limits
- Revised mermaid diagram to reflect the new simplified structure

### Documentation Standards Implemented
- ✅ YAML front matter with proper tags arrays
- ✅ Entity type indicators in titles (Entity/Template Entity/Value Object)
- ✅ Consistent section structure: Overview→Purpose→Structure→Example→See Also
- ✅ Comprehensive examples with mermaid diagrams
- ✅ Proper cross-references between related entities
- ✅ Line length compliance (120 characters max)

### Quality Assurance
- All 9 markdown files in Team domain now pass domain linter with 0 errors
- Documentation structure follows project guidelines
- Examples provide clear understanding of each model's purpose and usage
- Roster model now accurately reflects its core purpose

## Verification

Run the domain linter to verify compliance:
\\\ash
cd documents/scripts/linting
python domain_linter.py ../../docs/domains/team --report
\\\

Result: ✅ No linting errors found!

Closes #65